### PR TITLE
Update to RMB25

### DIFF
--- a/folio-service-tools-dev/src/main/java/org/folio/db/DbUtils.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/db/DbUtils.java
@@ -1,9 +1,9 @@
 package org.folio.db;
 
 import io.vertx.core.json.JsonArray;
-import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
-import org.z3950.zing.cql.cql2pgjson.FieldException;
 
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.cql.CQLWrapper;

--- a/folio-service-tools-dev/src/main/java/org/folio/rest/exc/RestExceptionHandlers.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/rest/exc/RestExceptionHandlers.java
@@ -17,10 +17,10 @@ import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
-import org.z3950.zing.cql.cql2pgjson.CQL2PgJSONException;
 
 import org.folio.common.pf.PartialFunction;
 import org.folio.common.pf.PartialFunctions;
+import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.folio.rest.tools.utils.ValidationHelper;
 

--- a/folio-service-tools-dev/src/test/java/org/folio/rest/exc/RestExceptionHandlersTest.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/rest/exc/RestExceptionHandlersTest.java
@@ -17,10 +17,10 @@ import com.github.mauricio.async.db.postgresql.messages.backend.ErrorMessage;
 import com.github.mauricio.async.db.postgresql.messages.backend.InformationMessage;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
-import org.z3950.zing.cql.cql2pgjson.CQL2PgJSONException;
 import scala.collection.immutable.Map;
 
 import org.folio.common.pf.PartialFunction;
+import org.folio.cql2pgjson.exception.CQL2PgJSONException;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 
 public class RestExceptionHandlersTest {

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
       <dependency>
         <groupId>org.folio</groupId>
         <artifactId>domain-models-runtime</artifactId>
-        <version>24.0.0</version>
+        <version>25.0.1</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>


### PR DESCRIPTION
## Purpose
Update to use `RMB 25.0.1`. This is necessary for `mod-notes` to be updated to RMB 25.

## Approach
Updated POM file and a few Java references due to package renaming.

#### TODOs and Open Questions
None.

## Learning
N/A.
