### PR TITLE
MODNOTES-114  Populate PK/FK/Unique exceptions with column details and invalid values

### DIFF
--- a/folio-service-tools-dev/src/main/java/org/folio/db/exc/ConstraintViolationException.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/db/exc/ConstraintViolationException.java
@@ -1,9 +1,15 @@
 package org.folio.db.exc;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.Validate;
+
 public class ConstraintViolationException extends DatabaseException {
 
   private String detailedMessage;
   private Constraint constraint;
+  private Map<String, String> invalidValues;
 
 
   public ConstraintViolationException(String message, String sqlState, Constraint constraint) {
@@ -23,6 +29,7 @@ public class ConstraintViolationException extends DatabaseException {
     super(message, cause, sqlState);
     this.detailedMessage = detailedMessage;
     this.constraint = constraint;
+    this.invalidValues = new HashMap<>();
   }
 
   public String getDetailedMessage() {
@@ -36,4 +43,14 @@ public class ConstraintViolationException extends DatabaseException {
   public Constraint.Type getConstraintType() {
     return constraint.getType();
   }
+
+  public void addInvalidValue(String fieldName, String value) {
+    Validate.notBlank(fieldName);
+    invalidValues.put(fieldName, value);
+  }
+
+  public Map<String, String> getInvalidValues() {
+    return new HashMap<>(invalidValues);
+  }
+
 }

--- a/folio-service-tools-dev/src/main/java/org/folio/db/exc/translation/postgresql/ConstrainViolationTranslation.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/db/exc/translation/postgresql/ConstrainViolationTranslation.java
@@ -53,7 +53,13 @@ class ConstrainViolationTranslation {
 
       Constraint constraint = createConstraint(sqlState, constName, table, column);
 
-      return new ConstraintViolationException(msg, exc, sqlState.getCode(), details, constraint);
+      ConstraintViolationException cve = new ConstraintViolationException(msg, exc, sqlState.getCode(),
+          details, constraint);
+
+      InvalidValueParser p = new InvalidValueParser(em);
+      p.parse().entrySet().forEach(entry -> cve.addInvalidValue(entry.getKey(), entry.getValue()));
+
+      return cve;
     }
 
     private Constraint createConstraint(PSQLState sqlState, String constName, String table, String column) {

--- a/folio-service-tools-dev/src/main/java/org/folio/db/exc/translation/postgresql/InvalidValueParser.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/db/exc/translation/postgresql/InvalidValueParser.java
@@ -1,0 +1,55 @@
+package org.folio.db.exc.translation.postgresql;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.collections4.IterableGet;
+import org.apache.commons.collections4.map.HashedMap;
+
+class InvalidValueParser {
+
+  private static final HashedMap<String, String> EMPTY_MAP = new HashedMap<>(0);
+
+  // Sample message to be parsed:
+  //  Key (parent_id1, parent_id2)=(22222, 813205855) is not present in table
+  //
+  // It always starts with "Key" and contains the data in form of
+  //    (<field-name1>, .. , <field-nameN>)=(<value1>, .. , <valueN>)
+  private static final Pattern VALUE_PATTERN =
+    Pattern.compile("\\s*Key\\s*\\((.+)\\)\\s*=\\s*\\((.+)\\).+");
+
+  private String details;
+
+
+  InvalidValueParser(ErrorMessageAdapter messageAdapter) {
+    this.details = messageAdapter.getDetailedMessage().orElse(null);
+  }
+
+  IterableGet<String, String> parse() {
+    if (isBlank(details)) {
+      return EMPTY_MAP;
+    }
+
+    HashedMap<String, String> result = new HashedMap<>();
+
+    Matcher matcher = VALUE_PATTERN.matcher(details);
+    if (matcher.matches()) {
+      String[] keys = matcher.group(1).split(",");
+      String[] values = matcher.group(2).split(",");
+
+      if (keys.length == values.length) {
+        for (int i = 0; i < keys.length; i++) {
+          String key = keys[i].trim();
+          String value = values[i].trim();
+
+          result.put(key, value);
+        }
+      }
+    }
+
+    return result;
+  }
+
+}

--- a/folio-service-tools-dev/src/test/java/org/folio/db/ErrorFactory.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/db/ErrorFactory.java
@@ -126,7 +126,8 @@ public class ErrorFactory {
   public static Map<Object, String> getExclusionViolationErrorMap(){
     return new ErrorBuilder()
       .setMessage("conflicting key value violates exclusion constraint \"exclude_overlapping_bookings\"")
-      .setDetail("Key (daterange(from_date, to_date, '[]'::text))=([2017-04-20,2017-05-01)) conflicts with existing key (daterange(from_date, to_date, '[]'::text))=([2017-04-20,2017-04-22))")
+      .setDetail("Key (daterange(from_date, to_date, '[]'::text))=([2017-04-20,2017-05-01)) " +
+        "conflicts with existing key (daterange(from_date, to_date, '[]'::text))=([2017-04-20,2017-04-22))")
       .setSchema(SCHEMA_NAME)
       .setTable("booking")
       .setLine("839")

--- a/folio-service-tools-dev/src/test/java/org/folio/db/exc/translation/postgresql/ConstrainViolationTranslationTest.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/db/exc/translation/postgresql/ConstrainViolationTranslationTest.java
@@ -1,12 +1,15 @@
 package org.folio.db.exc.translation.postgresql;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.folio.db.ErrorConstants.CHILD_TABLE_NAME;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 
+import static org.folio.db.ErrorConstants.CHILD_TABLE_NAME;
 import static org.folio.db.ErrorFactory.getCheckViolationErrorMap;
 import static org.folio.db.ErrorFactory.getDataLengthMismatch;
 import static org.folio.db.ErrorFactory.getDataTypeMismatchViolation;
@@ -129,5 +132,17 @@ public class ConstrainViolationTranslationTest {
   public void shouldThrowExceptionWhenReceivesNotIntegrityConstraintViolation(){
     GenericDatabaseException exception = new GenericDatabaseException(new ErrorMessage(getDataTypeMismatchViolation()));
     new ConstrainViolationTranslation.TFunction().apply(exception);
+  }
+
+  @Test
+  public void shouldReturnConstraintViolationExceptionWithInvalidFieldsPopulated(){
+    // detail: "Key (id1, id2)=(22222, 813205855) already exists"
+    GenericDatabaseException exception = new GenericDatabaseException(new ErrorMessage(getPrimaryKeyErrorMap()));
+    final ConstraintViolationException resultException = new ConstrainViolationTranslation.TFunction().apply(exception);
+
+    assertThat(resultException.getInvalidValues(), notNullValue());
+    assertThat(resultException.getInvalidValues().size(), is(2));
+    assertThat(resultException.getInvalidValues(), hasEntry("id1", "22222"));
+    assertThat(resultException.getInvalidValues(), hasEntry("id2", "813205855"));
   }
 }

--- a/folio-service-tools-dev/src/test/java/org/folio/db/exc/translation/postgresql/InvalidValueParserTest.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/db/exc/translation/postgresql/InvalidValueParserTest.java
@@ -1,0 +1,83 @@
+package org.folio.db.exc.translation.postgresql;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.github.mauricio.async.db.postgresql.messages.backend.ErrorMessage;
+import org.apache.commons.collections4.IterableGet;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import org.folio.db.ErrorFactory;
+import org.folio.test.junit.TestStartLoggingRule;
+
+public class InvalidValueParserTest {
+
+  @Rule
+  public TestRule startLogger = TestStartLoggingRule.instance();
+
+
+  @Test
+  public void parsesToSingleValue() {
+    ErrorMessageAdapter em = new ErrorMessageAdapter(new ErrorMessage(
+      ErrorFactory.getErrorMapWithDetailOnly("Key (name)=(John) already exists")));
+
+    IterableGet<String, String> values = new InvalidValueParser(em).parse();
+
+    assertThat(values.size(), is(1));
+    assertThat(values.containsKey("name"), is(true));
+    assertThat(values.containsValue("John"), is(true));
+  }
+
+  @Test
+  public void parsesToSeveralValues() {
+    ErrorMessageAdapter em = new ErrorMessageAdapter(new ErrorMessage(ErrorFactory.getErrorMapWithDetailOnly(
+        "Key (parent_id1, parent_id2)=(22222, 813205855) is not present in table \"parent\".")));
+
+    IterableGet<String, String> values = new InvalidValueParser(em).parse();
+
+    assertThat(values.size(), is(2));
+
+    assertThat(values.containsKey("parent_id1"), is(true));
+    assertThat(values.get("parent_id1"), is("22222"));
+
+    assertThat(values.containsKey("parent_id2"), is(true));
+    assertThat(values.get("parent_id2"), is("813205855"));
+  }
+
+  @Test
+  public void trimExcessiveSpacesFromKeysValues() {
+    ErrorMessageAdapter em = new ErrorMessageAdapter(new ErrorMessage(ErrorFactory.getErrorMapWithDetailOnly(
+      "Key ( parent_id1  , parent_id2  ) = (  22222  , 813205855  ) is not present in table \"parent\".")));
+
+    IterableGet<String, String> values = new InvalidValueParser(em).parse();
+
+    assertThat(values.size(), is(2));
+
+    assertThat(values.containsKey("parent_id1"), is(true));
+    assertThat(values.get("parent_id1"), is("22222"));
+
+    assertThat(values.containsKey("parent_id2"), is(true));
+    assertThat(values.get("parent_id2"), is("813205855"));
+  }
+
+  @Test
+  public void parsesToNoValuesIfDetailIsEmpty() {
+    ErrorMessageAdapter em = new ErrorMessageAdapter(new ErrorMessage(ErrorFactory.getErrorMapWithDetailNull()));
+
+    IterableGet<String, String> values = new InvalidValueParser(em).parse();
+
+    assertThat(values.isEmpty(), is(true));
+  }
+
+  @Test
+  public void parsesToNoValuesIfPatternDoesntMatch() {
+    ErrorMessageAdapter em = new ErrorMessageAdapter(new ErrorMessage(ErrorFactory.getErrorMapWithDetailOnly(
+      "Failing row contains (1697635108, 858317485, null, 4670207833.23).")));
+
+    IterableGet<String, String> values = new InvalidValueParser(em).parse();
+
+    assertThat(values.isEmpty(), is(true));
+  }
+}


### PR DESCRIPTION
## Purpose
Per [MODNOTES-114](https://issues.folio.org/browse/MODNOTES-114), populate PK/FK/Unique exceptions with column details and invalid values

## Approach
- modify ConstraintViolationException translation to parse invalid values from Detail message of postgres exception
