### PR TITLE
MODCFIELDS-6: Move TestBase to folio-service-tools

### DIFF
--- a/folio-service-tools-dev/pom.xml
+++ b/folio-service-tools-dev/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
-      <version>2.26.0</version>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/folio-service-tools-test/pom.xml
+++ b/folio-service-tools-test/pom.xml
@@ -18,6 +18,14 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>domain-models-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.folio.okapi</groupId>
+      <artifactId>okapi-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
     </dependency>

--- a/folio-service-tools-test/src/main/java/org/folio/test/util/DBTestUtil.java
+++ b/folio-service-tools-test/src/main/java/org/folio/test/util/DBTestUtil.java
@@ -1,0 +1,59 @@
+package org.folio.test.util;
+
+import static org.folio.test.util.TestUtil.STUB_TENANT;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+
+import io.vertx.core.Vertx;
+
+public class DBTestUtil {
+
+  private static final String JSONB_COLUMN = "jsonb";
+
+  private DBTestUtil() {
+  }
+
+  public static void save(String stubId, Object object, Vertx vertx, String tableName) {
+    save(stubId, object, vertx, tableName, STUB_TENANT);
+  }
+
+  public static void save(String stubId, Object object, Vertx vertx, String tableName, String tenantId) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx, tenantId).save(tableName, stubId, object,
+      event -> future.complete(null));
+    future.join();
+  }
+
+  public static <T> List<T> getAll(Class<T> valueType, Vertx vertx, String tableName) {
+    return getAll(valueType, vertx, tableName, STUB_TENANT);
+  }
+
+  public static <T> List<T> getAll(Class<T> valueType, Vertx vertx, String tableName, String tenantId) {
+    CompletableFuture<List<T>> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx, tenantId).get(tableName, valueType, JSONB_COLUMN,
+      "", false,false, false, results -> future.complete(results.result().getResults()));
+    return future.join();
+  }
+
+  public static void deleteFromTable(Vertx vertx, String tableName) {
+    deleteFromTable(vertx, tableName, STUB_TENANT);
+  }
+
+  public static void deleteFromTable(Vertx vertx, String tableName, String tenantId) {
+    try {
+      CompletableFuture<Void> future = new CompletableFuture<>();
+      PostgresClient.getInstance(vertx, tenantId).delete(tableName,
+        new CQLWrapper(new CQL2PgJSON("jsonb"), "cql.allRecords=1"),
+        event -> future.complete(null));
+      future.join();
+    } catch (FieldException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+}

--- a/folio-service-tools-test/src/main/java/org/folio/test/util/TestBase.java
+++ b/folio-service-tools-test/src/main/java/org/folio/test/util/TestBase.java
@@ -1,0 +1,193 @@
+package org.folio.test.util;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.test.util.TestUtil.STUB_TENANT;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.apache.http.entity.ContentType;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.test.junit.TestStartLoggingRule;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.rules.TestRule;
+
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.filter.log.LogDetail;
+import io.restassured.http.Header;
+import io.restassured.http.Headers;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import io.vertx.core.Vertx;
+import io.vertx.ext.unit.TestContext;
+
+/**
+ * Base test class for tests that use wiremock and vertx http servers,
+ * test that inherits this class must use VertxUnitRunner as test runner
+ * <p>
+ *
+ * BeforeClass and AfterClass methods have to run in order for this class to work correctly,
+ * if superclass declares its own @BeforeClass or @AfterClass methods, then they shouldn't hide existing
+ * methods (i.e. they should have different names).
+ * Alternatively superclass can hide existing methods and call TestBase#setUpClass/TestBase#tearDownClass methods directly.
+ * @see BeforeClass
+ * @see AfterClass
+ */
+public class TestBase {
+
+  protected static final Header JSON_CONTENT_TYPE_HEADER = new Header(HttpHeaders.CONTENT_TYPE,
+    ContentType.APPLICATION_JSON.getMimeType());
+
+  private static final String STUB_TOKEN = "TEST_OKAPI_TOKEN";
+  protected static HashMap<String, String> configProperties = new HashMap<>();
+  protected static int port;
+  protected static String host;
+  protected static Vertx vertx;
+
+  private static boolean needTeardown;
+
+  @Rule
+  public TestRule watcher = TestStartLoggingRule.instance();
+
+  @Rule
+  public WireMockRule wiremockServer = new WireMockRule(
+    WireMockConfiguration.wireMockConfig()
+      .dynamicPort()
+      .notifier(new Slf4jNotifier(true)));
+
+
+  /**
+   * @param context This parameter is added so that superclasses can hide this method by declaring their own
+   *                setUpClass(TestContext context) method.
+   */
+  @BeforeClass
+  public static void setUpClass(TestContext context) {
+    if (!TestSetUpHelper.isStarted()) {
+      TestSetUpHelper.startVertxAndPostgres(configProperties);
+      needTeardown = true;
+    } else {
+      needTeardown = false;
+    }
+    port = TestSetUpHelper.getPort();
+    host = TestSetUpHelper.getHost();
+    vertx = TestSetUpHelper.getVertx();
+  }
+
+  @AfterClass
+  public static void tearDownClass(TestContext context) {
+    if (needTeardown) {
+      TestSetUpHelper.stopVertxAndPostgres();
+    }
+  }
+
+
+  protected RequestSpecification getRequestSpecification() {
+    return new RequestSpecBuilder()
+      .addHeader(XOkapiHeaders.TENANT, STUB_TENANT)
+      .addHeader(XOkapiHeaders.TOKEN, STUB_TOKEN)
+      .addHeader(XOkapiHeaders.URL, getWiremockUrl())
+      .setBaseUri(host + ":" + port)
+      .setPort(port)
+      .log(LogDetail.ALL)
+      .build();
+  }
+
+  protected RequestSpecification givenWithUrl() {
+    return new RequestSpecBuilder()
+      .addHeader(XOkapiHeaders.URL, getWiremockUrl())
+      .setBaseUri(host + ":" + port)
+      .setPort(port)
+      .log(LogDetail.ALL)
+      .build();
+  }
+
+  /**
+   * Returns url of Wiremock server used in this test
+   */
+  protected String getWiremockUrl() {
+    return host + ":" + wiremockServer.port();
+  }
+
+  protected ExtractableResponse<Response> getWithOk(String resourcePath) {
+    return getWithStatus(resourcePath, HttpStatus.SC_OK);
+  }
+
+  protected ExtractableResponse<Response> deleteWithNoContent(String resourcePath) {
+    return deleteWithStatus(resourcePath, HttpStatus.SC_NO_CONTENT);
+  }
+
+  protected ExtractableResponse<Response> putWithNoContent(String resourcePath, String putBody, Header... headers) {
+    return putWithStatus(resourcePath, putBody, HttpStatus.SC_NO_CONTENT, headers);
+  }
+
+  protected ExtractableResponse<Response> getWithStatus(String resourcePath, int expectedStatus) {
+    return given()
+      .spec(getRequestSpecification())
+      .when()
+      .get(resourcePath)
+      .then()
+      .log().ifValidationFails()
+      .statusCode(expectedStatus).extract();
+  }
+
+  protected ValidatableResponse getWithValidateBody(String resourcePath, int expectedStatus) {
+    return given()
+      .spec(getRequestSpecification())
+      .when()
+      .get(resourcePath)
+      .then()
+      .log().ifValidationFails()
+      .statusCode(expectedStatus);
+  }
+
+  protected ExtractableResponse<Response> putWithStatus(String resourcePath, String putBody,
+                                                        int expectedStatus, Header... headers) {
+    return given()
+      .spec(getRequestSpecification())
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .headers(new Headers(headers))
+      .body(putBody)
+      .when()
+      .put(resourcePath)
+      .then()
+      .log().ifValidationFails()
+      .statusCode(expectedStatus)
+      .extract();
+  }
+
+  protected ExtractableResponse<Response> postWithStatus(String resourcePath, String postBody,
+                                                         int expectedStatus, Header... headers) {
+    return given()
+      .spec(getRequestSpecification())
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .headers(new Headers(headers))
+      .body(postBody)
+      .when()
+      .post(resourcePath)
+      .then()
+      .log().ifValidationFails()
+      .statusCode(expectedStatus)
+      .extract();
+  }
+
+  protected ExtractableResponse<Response> deleteWithStatus(String resourcePath, int expectedStatus) {
+    return given()
+      .spec(getRequestSpecification())
+      .when()
+      .delete(resourcePath)
+      .then()
+      .log().ifValidationFails()
+      .statusCode(expectedStatus)
+      .extract();
+  }
+}

--- a/folio-service-tools-test/src/main/java/org/folio/test/util/TestSetUpHelper.java
+++ b/folio-service-tools-test/src/main/java/org/folio/test/util/TestSetUpHelper.java
@@ -1,0 +1,94 @@
+package org.folio.test.util;
+
+import static org.folio.test.util.TestUtil.STUB_TENANT;
+import static org.folio.test.util.TestUtil.STUB_TOKEN;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+import org.folio.rest.RestVerticle;
+import org.folio.rest.client.TenantClient;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.tools.utils.NetworkUtils;
+
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import java.util.Map;
+
+public class TestSetUpHelper {
+  private static final String HTTP_PORT = "http.port";
+
+  private static int port;
+  private static String host;
+  private static boolean started;
+  private static Vertx vertx;
+
+  public static void startVertxAndPostgres() {
+    startVertxAndPostgres(Collections.emptyMap());
+  }
+
+  public static void startVertxAndPostgres(Map<String, String> configProperties) {
+    vertx = Vertx.vertx();
+    port = NetworkUtils.nextFreePort();
+    host = "http://127.0.0.1";
+
+
+    try {
+      PostgresClient.getInstance(vertx)
+        .startEmbeddedPostgres();
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed to start embedded postgres" , e);
+    }
+
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.deployVerticle(RestVerticle.class.getName(), getDeploymentOptions(configProperties), event -> {
+      TenantClient tenantClient = new TenantClient(host + ":" + port, STUB_TENANT, STUB_TOKEN);
+      try {
+        tenantClient.postTenant(null, res2 -> future.complete(null));
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    });
+    future.join();
+
+    started = true;
+  }
+
+  public static void stopVertxAndPostgres() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    vertx.close(res -> {
+      PostgresClient.stopEmbeddedPostgres();
+      future.complete(null);
+    });
+    future.join();
+    started = false;
+  }
+
+  public static boolean isStarted() {
+    return started;
+  }
+
+  public static int getPort() {
+    return port;
+  }
+
+  public static String getHost() {
+    return host;
+  }
+
+  public static Vertx getVertx() {
+    return vertx;
+  }
+
+
+  private static DeploymentOptions getDeploymentOptions(Map<String, String> configProperties) {
+    JsonObject config = new JsonObject()
+      .put(HTTP_PORT, port);
+    configProperties.forEach(config::put);
+    return new DeploymentOptions().setConfig(config
+    );
+  }
+}

--- a/folio-service-tools-test/src/main/java/org/folio/test/util/TestUtil.java
+++ b/folio-service-tools-test/src/main/java/org/folio/test/util/TestUtil.java
@@ -1,11 +1,17 @@
 package org.folio.test.util;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import com.github.tomakehurst.wiremock.matching.ContentPattern;
 import com.github.tomakehurst.wiremock.matching.RegexPattern;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.github.tomakehurst.wiremock.matching.UrlPathPattern;
+
 import io.vertx.core.json.Json;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
@@ -13,12 +19,15 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
 import org.apache.commons.io.FileUtils;
 
 public class TestUtil {
 
+  public static final String STUB_TENANT = "fs";
+  public static final String STUB_TOKEN = "TEST_OKAPI_TOKEN";
   private static final Logger LOG = LoggerFactory.getLogger("Test");
-
 
   private TestUtil() {
   }
@@ -35,6 +44,13 @@ public class TestUtil {
   }
 
   /**
+   * Reads json file from classpath and parses it into object of specified class
+   */
+  public static <T> T readJsonFile(String filename, Class<T> valueType) throws IOException, URISyntaxException {
+    return new ObjectMapper().readValue(FileUtils.readFileToString(getFile(filename), StandardCharsets.UTF_8), valueType);
+  }
+
+  /**
    * Returns File object corresponding to the file on classpath with specified filename
    */
   public static File getFile(String filename) throws URISyntaxException {
@@ -46,14 +62,62 @@ public class TestUtil {
     return Json.encode(object);
   }
 
+
   public static void mockGet(StringValuePattern urlPattern, String responseFile) throws IOException, URISyntaxException {
+    mockGetWithBody(urlPattern, readFile(responseFile));
+  }
+
+  public static void mockGetWithBody(StringValuePattern urlPattern, String body) {
     stubFor(get(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
       .willReturn(new ResponseDefinitionBuilder()
-        .withBody(readFile(responseFile))));
+        .withBody(body)));
   }
 
   public static void mockGet(StringValuePattern urlPattern, int status) {
     stubFor(get(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
       .willReturn(new ResponseDefinitionBuilder().withStatus(status)));
   }
+
+  public static void mockPost(StringValuePattern urlPattern, ContentPattern body, String response, int status) throws IOException, URISyntaxException {
+    stubFor(post(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
+      .withRequestBody(body)
+      .willReturn(new ResponseDefinitionBuilder()
+        .withBody(readFile(response))
+        .withStatus(status)));
+  }
+
+  public static void mockPut(StringValuePattern urlPattern, ContentPattern content, int status) {
+    stubFor(put(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
+      .withRequestBody(content)
+      .willReturn(new ResponseDefinitionBuilder()
+        .withStatus(status)));
+  }
+
+  public static void mockPut(StringValuePattern urlPattern, int status) {
+    stubFor(put(new UrlPathPattern(urlPattern, (urlPattern instanceof RegexPattern)))
+      .willReturn(new ResponseDefinitionBuilder()
+        .withStatus(status)));
+  }
+
+  public static void mockResponseList(UrlPathPattern urlPattern, ResponseDefinitionBuilder... responses) {
+    int scenarioStep = 0;
+    String scenarioName = "Scenario -" + UUID.randomUUID().toString();
+    for (ResponseDefinitionBuilder response : responses) {
+      if (scenarioStep == 0) {
+        stubFor(
+          get(urlPattern)
+            .inScenario(scenarioName)
+            .willSetStateTo(String.valueOf(++scenarioStep))
+            .willReturn(response));
+      } else {
+        stubFor(
+          get(urlPattern)
+            .inScenario(scenarioName)
+            .whenScenarioStateIs(String.valueOf(scenarioStep))
+            .willSetStateTo(String.valueOf(++scenarioStep))
+            .willReturn(response));
+      }
+    }
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
         <version>25.0.1</version>
       </dependency>
       <dependency>
+        <groupId>org.folio.okapi</groupId>
+        <artifactId>okapi-common</artifactId>
+        <version>2.26.0</version>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>


### PR DESCRIPTION
## Purpose
Refactor common test set up to remove duplication between modules

## Approach
Copy TestBase and TestSetUpHelper from mod-notes and mod-kb-ebsco-java
Generalize TestBase so that it can be used by any module that needs
to set up Vert.x + Wiremock + Postgres during tests.
Copy DBTestUtil from mod-notes
Generalize DBTestUtil

## Learning
`@BeforeClass` and `@AfterClass` methods from base class and from inheriting class can interact in a confusing way, so when extending TestBase we need to look out for that. 
https://stackoverflow.com/questions/2132734/beforeclass-and-inheritance-order-of-execution
