### PR TITLE
MODCFIELDS-27: Move utility methods from mod-kb-ebsco-java

### DIFF
--- a/folio-service-tools-dev/src/main/java/org/folio/db/DbUtils.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/db/DbUtils.java
@@ -1,20 +1,75 @@
 package org.folio.db;
 
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import io.vertx.ext.sql.SQLConnection;
 
+import org.apache.commons.lang3.mutable.MutableObject;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.util.FutureUtils;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+
+import static org.folio.util.FutureUtils.mapCompletableFuture;
 
 public final class DbUtils {
 
   @SuppressWarnings("squid:S2386")
   public static final String[] ALL_FIELDS = {"*"};
 
+  private static final Logger LOG = LoggerFactory.getLogger(DbUtils.class);
 
   private DbUtils() {}
+
+  public static <T> CompletableFuture<T> executeInTransaction(String tenantId, Vertx vertx,
+                                                              BiFunction<PostgresClient, AsyncResult<SQLConnection>, CompletableFuture<T>> action) {
+    PostgresClient postgresClient = PostgresClient.getInstance(vertx, tenantId);
+    MutableObject<AsyncResult<SQLConnection>> mutableConnection = new MutableObject<>();
+    MutableObject<T> mutableResult = new MutableObject<>();
+    CompletableFuture<Boolean> rollbackFuture = new CompletableFuture<>();
+
+    return CompletableFuture.completedFuture(null)
+      .thenCompose(o -> {
+        CompletableFuture<Void> startTxFuture = new CompletableFuture<>();
+        postgresClient.startTx(connection -> {
+          mutableConnection.setValue(connection);
+          startTxFuture.complete(null);
+        });
+        return startTxFuture;
+      })
+      .thenCompose(o -> action.apply(postgresClient, mutableConnection.getValue()))
+      .thenCompose(result -> {
+        mutableResult.setValue(result);
+        return endTransaction(postgresClient, mutableConnection);
+      })
+      .whenComplete((result, ex) -> {
+        if (ex != null) {
+          LOG.info("Transaction was not successful. Roll back changes.");
+          postgresClient.rollbackTx(mutableConnection.getValue(), rollback -> rollbackFuture.completeExceptionally(ex));
+        } else {
+          rollbackFuture.complete(null);
+        }
+      })
+      .thenCombine(rollbackFuture, (o, aBoolean) -> mutableResult.getValue());
+  }
+
+  public static <T> Future<T> executeInTransactionWithVertxFuture(String tenantId, Vertx vertx,
+                                                              BiFunction<PostgresClient,
+                                                                AsyncResult<SQLConnection>, Future<T>> action) {
+    BiFunction<PostgresClient, AsyncResult<SQLConnection>, CompletableFuture<T>> newAction = action.andThen(FutureUtils::mapVertxFuture);
+    return mapCompletableFuture(executeInTransaction(tenantId, vertx, newAction));
+  }
 
   public static CQLWrapper getCQLWrapper(String tableName, String query, int limit, int offset) throws FieldException {
     return getCQLWrapper(tableName, query)
@@ -40,4 +95,11 @@ public final class DbUtils {
 
     return parameters;
   }
+
+  private static CompletionStage<Void> endTransaction(PostgresClient postgresClient, MutableObject<AsyncResult<SQLConnection>> mutableConnection) {
+    Future<Void> future = Future.future();
+    postgresClient.endTx(mutableConnection.getValue(), future);
+    return FutureUtils.mapVertxFuture(future);
+  }
+
 }

--- a/folio-service-tools-dev/src/main/java/org/folio/util/FutureUtils.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/util/FutureUtils.java
@@ -1,6 +1,7 @@
 package org.folio.util;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.CompletableFuture;
 
 import io.vertx.core.Future;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
@@ -38,4 +39,26 @@ public final class FutureUtils {
     return result;
   }
 
+  public static <T> CompletableFuture<T> mapVertxFuture(Future<T> future) {
+    CompletableFuture<T> completableFuture = new CompletableFuture<>();
+
+    future
+      .map(completableFuture::complete)
+      .otherwise(completableFuture::completeExceptionally);
+
+    return completableFuture;
+  }
+
+  public static <T> Future<T> mapCompletableFuture(CompletableFuture<T> completableFuture) {
+    Future<T> future = Future.future();
+
+    completableFuture
+      .thenAccept(future::complete)
+      .exceptionally(cause -> {
+        future.fail(cause);
+        return null;
+      });
+
+    return future;
+  }
 }

--- a/folio-service-tools-dev/src/test/java/org/folio/db/DbUtilsTransactionTest.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/db/DbUtilsTransactionTest.java
@@ -1,0 +1,90 @@
+package org.folio.db;
+
+import org.folio.rest.persist.PostgresClient;
+import org.jetbrains.annotations.NotNull;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.SQLConnection;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+import static org.folio.test.util.TestUtil.STUB_TENANT;
+
+
+@RunWith(VertxUnitRunner.class)
+public class DbUtilsTransactionTest {
+
+  private static final String TEST_TABLE = "test_table";
+  private static final String INVALID_VALUE = "'abc'";
+  private static Vertx vertx = Vertx.vertx();
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws IOException {
+    PostgresClient.getInstance(vertx)
+      .startEmbeddedPostgres();
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    PostgresClient.getInstance(vertx).execute(
+      "CREATE TABLE " + TEST_TABLE + "(value INTEGER)",
+      event -> future.complete(null));
+    future.join();
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() {
+    PostgresClient
+      .stopEmbeddedPostgres();
+  }
+
+  @Test
+  public void shouldRollbackTransactionIfItFails(TestContext context) {
+    DbUtils.executeInTransactionWithVertxFuture(STUB_TENANT, vertx, (client, connection) ->
+      executeWithConnection(connection, "INSERT INTO " + TEST_TABLE + "(value) values(5)")
+        .compose(o -> executeWithConnection(connection, "INSERT INTO " + TEST_TABLE + "(value) values(" + INVALID_VALUE + ")")))
+    .setHandler(assertCount(0, context));
+  }
+
+  @Test
+  public void shouldCommitTransactionIfItSucceeds(TestContext context) {
+    DbUtils.executeInTransactionWithVertxFuture(STUB_TENANT, vertx, (client, connection) ->
+      executeWithConnection(connection, "INSERT INTO " + TEST_TABLE + "(value) values(5)"))
+      .setHandler((result) -> assertCount(1, context));
+  }
+
+  @Test
+  public void shouldNotCommitTransactionIfItStillInProgress(TestContext context) {
+    DbUtils.executeInTransactionWithVertxFuture(STUB_TENANT, vertx, (client, connection) ->
+      executeWithConnection(connection, "INSERT INTO " + TEST_TABLE + "(value) values(5)")
+    .compose(o -> assertCount(0, context))
+    .compose(o -> executeWithConnection(connection, "INSERT INTO " + TEST_TABLE + "(value) values(5)")))
+      .setHandler((result) -> assertCount(2, context));
+  }
+
+  private Future<Void> assertCount(int expectedCount, TestContext context) {
+      Future<ResultSet> future = Future.future();
+      PostgresClient.getInstance(vertx).select("SELECT COUNT(*) as count FROM " + TEST_TABLE, future);
+      return future.map(resultSet -> {
+        String count = resultSet.getRows().get(0).getString("count");
+        context.assertEquals(expectedCount, count);
+        return null;
+    });
+  }
+
+  @NotNull
+  private Future<Void> executeWithConnection(AsyncResult<SQLConnection> connection, String sql) {
+    Future<Void> future = Future.future();
+    PostgresClient.getInstance(vertx).execute(
+      connection, sql,
+      event -> future.complete(null));
+    return future;
+  }
+
+}

--- a/folio-service-tools-dev/src/test/java/org/folio/util/FutureUtilsTest.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/util/FutureUtilsTest.java
@@ -1,0 +1,73 @@
+package org.folio.util;
+
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import io.vertx.core.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class FutureUtilsTest {
+
+  private static final String RESULT_VALUE = "Completed";
+  private static final IllegalArgumentException EXCEPTION_VALUE = new IllegalArgumentException();
+
+  @Test
+  public void shouldCompleteVertxFutureWhenCompletableFutureSucceeds() {
+    CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+    Future<Object> vertxFuture = FutureUtils.mapCompletableFuture(completableFuture);
+    completableFuture.complete(RESULT_VALUE);
+    assertTrue(vertxFuture.succeeded());
+    vertxFuture.setHandler(result ->
+      assertEquals(RESULT_VALUE, result.result()));
+  }
+
+  @Test
+  public void shouldFailVertxFutureWhenCompletableFutureFails() {
+    CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+    Future<Object> vertxFuture = FutureUtils.mapCompletableFuture(completableFuture);
+    completableFuture.completeExceptionally(EXCEPTION_VALUE);
+    assertTrue(vertxFuture.failed());
+    vertxFuture.setHandler(result -> {
+      assertTrue(result.cause() instanceof CompletionException);
+      assertEquals(EXCEPTION_VALUE, result.cause().getCause());
+    });
+  }
+
+  @Test
+  public void shouldNotCompleteVertxFutureWhenCompletableFutureNotCompleted() {
+    CompletableFuture<Object> completableFuture = new CompletableFuture<>();
+    Future<Object> vertxFuture = FutureUtils.mapCompletableFuture(completableFuture);
+    assertFalse(vertxFuture.isComplete());
+  }
+
+  @Test
+  public void shouldCompleteCompletableFutureWhenVertxFutureSucceeds() {
+    Future<Object> vertxFuture = Future.future();
+    CompletableFuture<Object> completableFuture = FutureUtils.mapVertxFuture(vertxFuture);
+    completableFuture.complete(RESULT_VALUE);
+    assertEquals(RESULT_VALUE, completableFuture.getNow(null));
+  }
+
+  @Test
+  public void shouldFailCompletableFutureWhenVertxFutureFails() {
+    Future<Object> vertxFuture = Future.future();
+    CompletableFuture<Object> completableFuture = FutureUtils.mapVertxFuture(vertxFuture);
+    completableFuture.completeExceptionally(EXCEPTION_VALUE);
+    assertTrue(completableFuture.isCompletedExceptionally());
+    completableFuture.exceptionally(ex -> {
+      assertEquals(EXCEPTION_VALUE, ex.getCause());
+      return null;
+    });
+  }
+
+  @Test
+  public void shouldNotCompleteCompletableFutureWhenVertxFutureNotCompleted() {
+    Future<Object> vertxFuture = Future.future();
+    CompletableFuture<Object> completableFuture = FutureUtils.mapVertxFuture(vertxFuture);
+    assertFalse(completableFuture.isDone());
+  }
+}


### PR DESCRIPTION
## Purpose
Make utility methods available for mod-custom-fields

## Approach
Copy executeInTransaction method to DbUtils
Copy mapVertxFuture and mapCompletableFuture methods to FutureUtils