### PR TITLE
MODKBEKBJ-432 Сonvert headers to case insensitive in TokenUtils.fetchUserInfo()

### DIFF
--- a/folio-service-tools-dev/src/main/java/org/folio/util/TokenUtils.java
+++ b/folio-service-tools-dev/src/main/java/org/folio/util/TokenUtils.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.NotAuthorizedException;
 
 import io.vertx.core.json.JsonObject;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang.StringUtils;
 
 import org.folio.okapi.common.XOkapiHeaders;
@@ -50,7 +51,7 @@ public final class TokenUtils {
   }
 
   public static CompletableFuture<UserInfo> fetchUserInfo(Map<String, String> okapiHeaders) {
-    Map<String, String> h = defaultIfNull(okapiHeaders, Collections.emptyMap());
+    Map<String, String> h = new CaseInsensitiveMap<>(defaultIfNull(okapiHeaders, Collections.emptyMap()));
 
     return fetchUserInfo(h.get(XOkapiHeaders.TOKEN));
   }

--- a/folio-service-tools-dev/src/test/java/org/folio/util/TokenUtilsTest.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/util/TokenUtilsTest.java
@@ -71,6 +71,19 @@ public class TokenUtilsTest {
   }
 
   @Test
+  public void testFetchIsCaseInsensitiveToHeaderNames() throws ExecutionException, InterruptedException {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(XOkapiHeaders.TOKEN.toUpperCase(), VALID_TOKEN);
+
+    CompletableFuture<UserInfo> future = TokenUtils.fetchUserInfo(headers);
+
+    UserInfo result = future.get();
+
+    assertEquals(USER_ID, result.getUserId());
+    assertEquals(USER_NAME, result.getUserName());
+  }
+
+  @Test
   public void testFetchFailedWithNotAuthorizedWhenEmptyToken() {
     Future<UserInfo> result = mapCompletableFuture(TokenUtils.fetchUserInfo(Collections.emptyMap()));
 


### PR DESCRIPTION
## Purpose
Сonvert headers to case insensitive in `TokenUtils.fetchUserInfo(Map<String, String> okapiHeaders)`

## Approach
 Use `CaseInsensitiveMap` to wrap original headers map