### PR TITLE
FST-17 Kiwi R3 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## v1.8.0-SNAPSHOT 2021-xx-xx
+* FST-17: Kiwi R3 2021 - Log4j vulnerability verification and correction
+
 ## v1.7.1 2021-10-04
 * FST-15: Upgrade folio-service-tools to RMB 33.1.1 and Vert.x 4.1.4
 * FST-16: Upgrade folio-service-tools to mod-configuration-client 5.7.1

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <vertx.version>4.1.4</vertx.version>
-    <raml-module-builder.version>33.1.3</raml-module-builder.version>
+    <raml-module-builder.version>33.1.1</raml-module-builder.version>
     <log4j-slf4j-impl.version>2.16.0</log4j-slf4j-impl.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>3.12.4</mockito.version>
@@ -34,6 +34,7 @@
     <easy-random.version>5.0.0</easy-random.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <log4j.version>2.16.0</log4j.version>
   </properties>
 
   <dependencyManagement>
@@ -59,6 +60,13 @@
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j-slf4j-impl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>${log4j.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 
   <properties>
     <vertx.version>4.1.4</vertx.version>
-    <raml-module-builder.version>33.1.1</raml-module-builder.version>
-    <log4j-slf4j-impl.version>2.14.1</log4j-slf4j-impl.version>
+    <raml-module-builder.version>33.1.3</raml-module-builder.version>
+    <log4j-slf4j-impl.version>2.16.0</log4j-slf4j-impl.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>3.12.4</mockito.version>
     <wiremock.version>2.27.2</wiremock.version>


### PR DESCRIPTION
## Purpose
Fix log4j2 `RCE` vulnerability

## Approach
- log4j version set to 2.16.0

## Learning
[FST-17](https://issues.folio.org/browse/FST-17)
[CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)
[CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33)
`mvn dependency:tree -Dincludes=org.apache.logging.log4j` can be used to check log4j versions used
