### PR TITLE
FST-19 Upgrade to RAML Module Builder 33.2.4

### DIFF
--- a/folio-service-tools-dev/pom.xml
+++ b/folio-service-tools-dev/pom.xml
@@ -13,8 +13,8 @@
   <name>folio-service-tools-dev</name>
 
   <properties>
-    <httpcore.version>4.4.14</httpcore.version>
-    <mod-configuration-client.version>5.7.1</mod-configuration-client.version>
+    <httpcore.version>4.4.15</httpcore.version>
+    <mod-configuration-client.version>5.7.4</mod-configuration-client.version>
     <sonar.exclusions>
       src/main/java/**/PartialFunctions.*,
       src/main/java/**/service/exc/*,

--- a/pom.xml
+++ b/pom.xml
@@ -24,17 +24,17 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.1.4</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <raml-module-builder.version>33.2.4</raml-module-builder.version>
     <log4j-slf4j-impl.version>2.16.0</log4j-slf4j-impl.version>
     <junit.version>4.13.2</junit.version>
-    <mockito.version>3.12.4</mockito.version>
+    <mockito.version>4.2.0</mockito.version>
     <wiremock.version>2.27.2</wiremock.version>
     <rest-assured.version>4.4.0</rest-assured.version>
     <easy-random.version>5.0.0</easy-random.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <log4j.version>2.16.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
   <properties>
     <vertx.version>4.1.4</vertx.version>
-    <raml-module-builder.version>33.1.1</raml-module-builder.version>
+    <raml-module-builder.version>33.2.4</raml-module-builder.version>
     <log4j-slf4j-impl.version>2.16.0</log4j-slf4j-impl.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>3.12.4</mockito.version>


### PR DESCRIPTION
## Purpose
Update to the latest RMB 33.2.* release.

See details: https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md

## Learning
[FST-19](https://issues.folio.org/browse/FST-19)
