### PR TITLE
FST-21: wiremock-jre8:2.32.0 fixing security vulnerabilities

### DIFF
--- a/folio-service-tools-dev/pom.xml
+++ b/folio-service-tools-dev/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/folio-service-tools-test/pom.xml
+++ b/folio-service-tools-test/pom.xml
@@ -64,7 +64,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jre8</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <log4j-slf4j-impl.version>2.16.0</log4j-slf4j-impl.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>4.2.0</mockito.version>
-    <wiremock.version>2.27.2</wiremock.version>
+    <wiremock.version>2.32.0</wiremock.version>
     <rest-assured.version>4.4.0</rest-assured.version>
     <easy-random.version>5.0.0</easy-random.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -82,7 +82,7 @@
       </dependency>
       <dependency>
         <groupId>com.github.tomakehurst</groupId>
-        <artifactId>wiremock</artifactId>
+        <artifactId>wiremock-jre8</artifactId>
         <version>${wiremock.version}</version>
         <scope>test</scope>
         <exclusions>


### PR DESCRIPTION
Update from wiremock:2.27.2 to wiremock-jre8:2.32.0.

This fixes multiple security vulnerabilities: https://mvnrepository.com/artifact/com.github.tomakehurst/wiremock/2.27.2

Explanation of the difference between wiremock and wiremock-jre8: http://wiremock.org/docs/download-and-installation/