### PR TITLE
FST-24: jackson-databind 2.13.2.1 Denial of Service (CVE-2020-36518)

### DIFF
--- a/folio-service-tools-dev/pom.xml
+++ b/folio-service-tools-dev/pom.xml
@@ -14,7 +14,7 @@
 
   <properties>
     <httpcore.version>4.4.15</httpcore.version>
-    <mod-configuration-client.version>5.7.5</mod-configuration-client.version>
+    <mod-configuration-client.version>5.7.7</mod-configuration-client.version>
     <sonar.exclusions>
       src/main/java/**/PartialFunctions.*,
       src/main/java/**/service/exc/*,

--- a/pom.xml
+++ b/pom.xml
@@ -24,14 +24,14 @@
   </licenses>
 
   <properties>
-    <vertx.version>4.2.5</vertx.version>
-    <raml-module-builder.version>33.2.6</raml-module-builder.version>
+    <vertx.version>4.2.7</vertx.version>
+    <raml-module-builder.version>33.2.9</raml-module-builder.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>4.3.1</mockito.version>
-    <wiremock.version>2.32.0</wiremock.version>
+    <wiremock.version>2.33.2</wiremock.version>
     <rest-assured.version>4.5.1</rest-assured.version>
     <easy-random.version>5.0.0</easy-random.version>
-    <log4j.version>2.17.1</log4j.version>
+    <log4j.version>2.17.2</log4j.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>


### PR DESCRIPTION
Upgrade RMB, Vert.x, mod-configuration-client and Wiremock to indirectly upgrade jackson-databind from 2.13.1 to 2.13.2.1 fixing Denial of Service (DoS) https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518

Upgrade log4j from 2.17.1 to 2.17.2 because maintainers recommend it: https://logging.apache.org/log4j/2.x/