### PR TITLE
FST-29: Vertx 4.3.3, RMB 34.0.2, Wiremock 2.34.0 fixing vulns

### DIFF
--- a/folio-service-tools-dev/pom.xml
+++ b/folio-service-tools-dev/pom.xml
@@ -65,11 +65,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
       <scope>test</scope>
@@ -77,6 +72,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/folio-service-tools-test/pom.xml
+++ b/folio-service-tools-test/pom.xml
@@ -58,11 +58,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
       <scope>compile</scope>
@@ -70,6 +65,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
 
   <properties>
     <log4j.version>2.17.2</log4j.version>
-    <vertx.version>4.3.1</vertx.version>
-    <raml-module-builder.version>34.0.0</raml-module-builder.version>
+    <vertx.version>4.3.3</vertx.version>
+    <raml-module-builder.version>34.0.2</raml-module-builder.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -34,7 +34,7 @@
     <!-- Test dependencies versions -->
     <junit.version>4.13.2</junit.version>
     <mockito.version>4.6.1</mockito.version>
-    <wiremock.version>2.33.2</wiremock.version>
+    <wiremock.version>2.34.0</wiremock.version>
     <rest-assured.version>5.1.1</rest-assured.version>
     <easy-random.version>5.0.0</easy-random.version>
 


### PR DESCRIPTION
Upgrade Vert.x from 4.3.1 to 4.3.3 fixing SSL that was incorrectly disabled: https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web

This upgrades these vert.x dependencies:

* Upgrade jetty-client, jetty-http, and jetty-proxy from 9.4.46.v20220331 to 9.4.48.v20220622 fixing Improper Input Validation vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-2047

Upgrade RMB from 34.0.0 to 34.0.2 matching the Vert.x version.

Upgrade wiremock from 2.33.2 to 2.34.0. This upgrades these wiremock dependencies:

* Upgrade http2-server from 9.4.46.v20220331 to 9.4.48.v20220622 fixing an Insufficient Resource Pool vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-2048
* Upgrade commons-codec from 1.11 to 1.13 fixing an Information Exposure vulnerability: https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

In dependencies move restassured below wiremock, otherwise restassured undoes wiremock's commons-codec bump.