### PR TITLE
FST-42: Added null check on System user creation

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/PrepareSystemUserService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/PrepareSystemUserService.java
@@ -52,7 +52,7 @@ public class PrepareSystemUserService {
 
   private Optional<User> getFolioUser(String username) {
     var users = usersClient.query("username==" + username);
-    return users.getResult().stream().findFirst();
+    return (users == null || users.getResult() == null) ? Optional.empty() : users.getResult().stream().findFirst();
   }
 
   private void createFolioUser(String id) {

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/systemuser/PrepareSystemUserServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/systemuser/PrepareSystemUserServiceTest.java
@@ -49,6 +49,16 @@ class PrepareSystemUserServiceTest {
   }
 
   @Test
+  void shouldCreateSystemUserWhenNullResponse() {
+    when(usersClient.query(any())).thenReturn(null);
+
+    prepareSystemUser(systemUserProperties());
+
+    verify(usersClient).saveUser(any());
+    verify(permissionsClient).assignPermissionsToUser(any());
+  }
+
+  @Test
   void shouldNotCreateSystemUserWhenExists() {
     when(usersClient.query(any())).thenReturn(userExistsResponse());
     when(permissionsClient.getUserPermissions(any())).thenReturn(ResultList.empty());


### PR DESCRIPTION
### Purpose
_Avoid NPE while creating system user._

### Approach
**Added null check on the place where getting first result from fetched users list**

### Learning
[https://issues.folio.org/browse/FST-42](https://issues.folio.org/browse/FST-42)
