### PR TITLE
FST-46 Add userId to FolioExecutionContext for system-user

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/model/SystemUser.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/model/SystemUser.java
@@ -4,5 +4,5 @@ import lombok.Builder;
 import lombok.With;
 
 @Builder
-public record SystemUser(String username, String okapiUrl, String tenantId, @With String token) {
+public record SystemUser(String username, String okapiUrl, String tenantId, @With String token, @With String userId) {
 }

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/PrepareSystemUserService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/PrepareSystemUserService.java
@@ -50,7 +50,7 @@ public class PrepareSystemUserService {
     log.info("System user has been created");
   }
 
-  private Optional<User> getFolioUser(String username) {
+  public Optional<User> getFolioUser(String username) {
     var users = usersClient.query("username==" + username);
     return (users == null || users.getResult() == null) ? Optional.empty() : users.getResult().stream().findFirst();
   }

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/SystemUserExecutionContextBuilder.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/SystemUserExecutionContextBuilder.java
@@ -6,6 +6,7 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ public class SystemUserExecutionContextBuilder {
     var okapiUrl = systemUser.okapiUrl();
     var tenantId = systemUser.tenantId();
     var token = systemUser.token();
+    var userId = systemUser.userId();
 
     Map<String, Collection<String>> headers = new HashMap<>();
     if (isNotBlank(okapiUrl)) {
@@ -41,10 +43,14 @@ public class SystemUserExecutionContextBuilder {
     if (isNotBlank(token)) {
       headers.put(XOkapiHeaders.TOKEN, singleton(token));
     }
+    if (isNotBlank(userId)) {
+      headers.put(XOkapiHeaders.USER_ID, singleton(userId));
+    }
 
     return builder()
       .withTenantId(tenantId)
       .withOkapiUrl(okapiUrl)
+      .withUserId(userId)
       .withToken(token)
       .withOkapiHeaders(headers)
       .build();
@@ -60,6 +66,7 @@ public class SystemUserExecutionContextBuilder {
     private String tenantId;
     private String okapiUrl;
     private String token;
+    private String userId;
 
     public Builder(FolioModuleMetadata moduleMetadata) {
       this.moduleMetadata = moduleMetadata;
@@ -82,6 +89,11 @@ public class SystemUserExecutionContextBuilder {
         @Override
         public String getToken() {
           return token;
+        }
+
+        @Override
+        public UUID getUserId() {
+          return UUID.fromString(userId);
         }
 
         @Override

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/SystemUserService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/systemuser/SystemUserService.java
@@ -8,6 +8,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.folio.spring.tools.client.AuthnClient;
 import org.folio.spring.tools.client.AuthnClient.UserCredentials;
+import org.folio.spring.tools.client.UsersClient;
 import org.folio.spring.tools.config.properties.FolioEnvironment;
 import org.folio.spring.tools.model.SystemUser;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,7 @@ public class SystemUserService {
   private final SystemUserProperties systemUserProperties;
   private final FolioEnvironment environment;
   private final AuthnClient authnClient;
+  private final PrepareSystemUserService prepareUserService;
 
   private Cache<String, SystemUser> systemUserCache;
 
@@ -71,9 +73,11 @@ public class SystemUserService {
       .build();
 
     var token = authSystemUser(systemUser);
+    var userId = prepareUserService.getFolioUser(systemUserProperties.username())
+      .map(UsersClient.User::id).orElse(null);
 
     log.info("Token for system user has been issued [tenantId={}]", tenantId);
-    return systemUser.withToken(token);
+    return systemUser.withToken(token).withUserId(userId);
   }
 
 }

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/systemuser/SystemUserExecutionContextBuilderTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/systemuser/SystemUserExecutionContextBuilderTest.java
@@ -3,6 +3,7 @@ package org.folio.spring.tools.systemuser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.UUID;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.tools.model.SystemUser;
 import org.junit.jupiter.api.Test;
@@ -14,18 +15,21 @@ class SystemUserExecutionContextBuilderTest {
 
   @Test
   void canCreateSystemUserContext() {
+    var userId = UUID.randomUUID();
     var systemUser = SystemUser.builder()
       .token("token").username("username")
       .okapiUrl("okapi").tenantId("tenant")
+      .userId(userId.toString())
       .build();
     var context = builder.forSystemUser(systemUser);
 
     assertThat(context.getTenantId()).isEqualTo("tenant");
     assertThat(context.getToken()).isEqualTo("token");
     assertThat(context.getOkapiUrl()).isEqualTo("okapi");
+    assertThat(context.getUserId()).isEqualTo(userId);
 
     assertThat(context.getAllHeaders()).isNotNull();
-    assertThat(context.getOkapiHeaders()).isNotNull().hasSize(3);
+    assertThat(context.getOkapiHeaders()).isNotNull().hasSize(4);
     assertThat(context.getFolioModuleMetadata()).isNotNull();
   }
 

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/systemuser/SystemUserServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/systemuser/SystemUserServiceTest.java
@@ -10,10 +10,13 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import java.util.Optional;
+import java.util.UUID;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.tools.client.AuthnClient;
 import org.folio.spring.tools.client.AuthnClient.UserCredentials;
+import org.folio.spring.tools.client.UsersClient;
 import org.folio.spring.tools.config.properties.FolioEnvironment;
 import org.folio.spring.tools.model.SystemUser;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,8 @@ class SystemUserServiceTest {
   @Mock
   private FolioEnvironment environment;
   @Mock
+  private PrepareSystemUserService prepareSystemUserService;
+  @Mock
   private Cache<String, SystemUser> userCache;
 
   private static SystemUser systemUserValue() {
@@ -51,18 +56,23 @@ class SystemUserServiceTest {
 
   @Test
   void getAuthedSystemUser_positive() {
+    var expectedUserId = UUID.randomUUID();
     var expectedAuthToken = "x-okapi-token-value";
     var expectedHeaders = new HttpHeaders();
     expectedHeaders.add(XOkapiHeaders.TOKEN, expectedAuthToken);
     var systemUser = systemUserValue();
 
     when(authnClient.getApiKey(new UserCredentials("username", "password"))).thenReturn(expectedResponse);
+    when(prepareSystemUserService.getFolioUser("username"))
+      .thenReturn(Optional.of(new UsersClient.User(expectedUserId.toString(), "username",
+        true, new UsersClient.User.Personal("last"))));
     when(environment.getOkapiUrl()).thenReturn(OKAPI_URL);
     when(contextBuilder.forSystemUser(systemUser)).thenReturn(context);
     when(expectedResponse.getHeaders()).thenReturn(expectedHeaders);
 
     var actual = systemUserService(systemUserProperties()).getAuthedSystemUser(TENANT_ID);
     assertThat(actual.token()).isEqualTo(expectedAuthToken);
+    assertThat(actual.userId()).isEqualTo(expectedUserId.toString());
   }
 
   @Test
@@ -127,6 +137,6 @@ class SystemUserServiceTest {
   }
 
   private SystemUserService systemUserService(SystemUserProperties properties) {
-    return new SystemUserService(contextBuilder, properties, environment, authnClient);
+    return new SystemUserService(contextBuilder, properties, environment, authnClient, prepareSystemUserService);
   }
 }


### PR DESCRIPTION
### Purpose
FolioExecutionContext is used to store the context of HTTP or Kafka messaging interactions. It contains several parameters needed for modules to interact with each other: tenant, token, okapi url, user id. For now context that is created for interaction on the base of the system user doesn't contain the user id that may be required for some interactions.

### Approach
Do a call to /users to get id of the system-user ant put it into context