### PR TITLE
FST-48 Return default in context for getUserId() if it is blank

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/context/ExecutionContextBuilder.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/context/ExecutionContextBuilder.java
@@ -113,7 +113,7 @@ public class ExecutionContextBuilder {
 
         @Override
         public UUID getUserId() {
-          return UUID.fromString(userId);
+          return isNotBlank(userId) ? UUID.fromString(userId) : FolioExecutionContext.super.getUserId();
         }
 
         @Override


### PR DESCRIPTION
### Purpose
Return default in context for getUserId() if it is blank