### PR TITLE
FST-59: Added delete kafka topic method

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -46,11 +46,10 @@ public class KafkaAdminService {
     kafkaAdmin.initialize();
   }
 
-  public void deleteTopicsByTenant(String tenantId) {
+  public void deleteTopics(String tenantId) {
     var configTopics = kafkaProperties.getTopics();
     var topicsToDelete = configTopics.stream()
-      .map(topic->getTenantTopicName(topic.getName(), tenantId))
-      .filter(name -> name.startsWith(FolioEnvironment.getFolioEnvName() + "." + tenantId + "."))
+      .map(topic -> getTenantTopicName(topic.getName(), tenantId))
       .toList();
     log.info("Deleting topics for tenantId {}: [topics: {}]", tenantId, topicsToDelete);
     kafkaAdminClient.deleteTopics(topicsToDelete);

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -4,18 +4,15 @@ import static java.util.Optional.ofNullable;
 import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName;
 
 import java.util.List;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.folio.spring.tools.config.properties.FolioEnvironment;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.stereotype.Service;
-
-import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 
 @Log4j2
 @Service

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -50,6 +50,7 @@ public class KafkaAdminService {
                                                              .filter(t -> t.getName().contains("." + tenantId + "."))
                                                              .map(FolioKafkaProperties.KafkaTopic::getName)
                                                              .toList();
+    log.info("Deleting topics for tenantId {}: [topics: {}]", tenantId, topicsToDelete);
     kafkaAdminClient.deleteTopics(topicsToDelete);
   }
 

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -68,7 +68,8 @@ public class KafkaAdminService {
   private List<NewTopic> toTenantSpecificTopic(List<FolioKafkaProperties.KafkaTopic> localConfigTopics,
     String tenantId) {
     return localConfigTopics.stream()
-      .map(topic -> toKafkaTopic(topic, tenantId)).toList();
+      .map(topic -> toKafkaTopic(topic, tenantId))
+      .toList();
   }
 
   private NewTopic toKafkaTopic(FolioKafkaProperties.KafkaTopic topic, String tenantId) {

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -49,7 +49,7 @@ public class KafkaAdminService {
   public void deleteTopicsByTenant(String tenantId) {
     var configTopics = kafkaProperties.getTopics();
     var topicsToDelete = configTopics.stream()
-      .map(FolioKafkaProperties.KafkaTopic::getName)
+      .map(topic->getTenantTopicName(topic.getName(), tenantId))
       .filter(name -> name.startsWith(FolioEnvironment.getFolioEnvName() + "." + tenantId + "."))
       .toList();
     log.info("Deleting topics for tenantId {}: [topics: {}]", tenantId, topicsToDelete);

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -5,12 +5,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import org.apache.kafka.clients.admin.KafkaAdminClient;
-import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.folio.spring.tools.config.properties.FolioEnvironment;
 import org.junit.jupiter.api.Test;

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -63,11 +63,11 @@ class KafkaAdminServiceTest {
   @Test
   void deleteKafkaTopics_positive() {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
-    kafkaTopic.setName("folio.test_tenant.topic");
+    kafkaTopic.setName("test_topic");
     when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
 
     kafkaAdminService.deleteTopicsByTenant("test_tenant");
-    verify(kafkaAdminClient).deleteTopics(List.of("folio.test_tenant.topic"));
+    verify(kafkaAdminClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -5,8 +5,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.folio.spring.tools.config.properties.FolioEnvironment;
 import org.junit.jupiter.api.Test;
@@ -35,6 +39,8 @@ class KafkaAdminServiceTest {
   private KafkaAdmin kafkaAdmin;
   @MockBean
   private FolioKafkaProperties kafkaProperties;
+  @MockBean
+  private KafkaAdminClient kafkaAdminClient;
 
   @Test
   void createKafkaTopics_positive() {
@@ -52,6 +58,16 @@ class KafkaAdminServiceTest {
       new NewTopic("folio.test_tenant.topic2", Optional.empty(), Optional.of((short) 2)),
       new NewTopic("folio.test_tenant.topic3", Optional.of(30), Optional.of((short) -1))
     ));
+  }
+
+  @Test
+  void deleteKafkaTopics_positive() {
+    FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
+    kafkaTopic.setName("test.test_tenant.topic");
+    when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
+
+    kafkaAdminService.deleteTopicsByTenant("test_tenant");
+    verify(kafkaAdminClient).deleteTopics(List.of("test.test_tenant.topic"));
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -63,11 +63,11 @@ class KafkaAdminServiceTest {
   @Test
   void deleteKafkaTopics_positive() {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
-    kafkaTopic.setName("test.test_tenant.topic");
+    kafkaTopic.setName("folio.test_tenant.topic");
     when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
 
     kafkaAdminService.deleteTopicsByTenant("test_tenant");
-    verify(kafkaAdminClient).deleteTopics(List.of("test.test_tenant.topic"));
+    verify(kafkaAdminClient).deleteTopics(List.of("folio.test_tenant.topic"));
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -66,7 +66,7 @@ class KafkaAdminServiceTest {
     kafkaTopic.setName("test_topic");
     when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
 
-    kafkaAdminService.deleteTopicsByTenant("test_tenant");
+    kafkaAdminService.deleteTopics("test_tenant");
     verify(kafkaAdminClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
   }
 


### PR DESCRIPTION
### Purpose
Add kafka topic deletion by tenant id logic

### Approach
Added kafka topic deletion by tenant id method

### Learning
[FST-59](https://issues.folio.org/browse/FST-59)
