### PR TITLE
FST-60: Improved kafka topic deletion by tenant id

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -79,14 +79,20 @@ public class KafkaAdminService {
 
       DeleteTopicsResult deleteTopicsResult = kafkaClient.deleteTopics(topicsToBeDeleted);
 
-      try {
-        deleteTopicsResult.all().get();
-        log.info("Topics deleted successfully: {}", topicsToBeDeleted);
-      } catch (Exception ex) {
-        log.warn("Unable to delete topics for tenantId: {}", tenantId, ex);
-      }
+      processDeleteResult(tenantId, topicsToBeDeleted, deleteTopicsResult);
     } catch (Exception ex) {
       log.warn("Error occurred while deleting topics for tenantId: {}", tenantId, ex);
+    }
+  }
+
+  private static void processDeleteResult(String tenantId,
+                                          List<String> topicsToBeDeleted,
+                                          DeleteTopicsResult deleteTopicsResult) {
+    try {
+      deleteTopicsResult.all().get();
+      log.info("Topics deleted successfully: {}", topicsToBeDeleted);
+    } catch (Exception ex) {
+      log.warn("Unable to delete topics for tenantId: {}", tenantId, ex);
     }
   }
 

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -49,7 +49,7 @@ public class KafkaAdminService {
     kafkaAdmin.initialize();
   }
 
-  public void deleteTopics(String tenantId) {
+  public void deleteTopics(String tenantId) throws Exception {
     if (tenantId == null || tenantId.isEmpty()) {
       log.warn("Invalid tenantId: {}", tenantId);
       return;
@@ -79,21 +79,14 @@ public class KafkaAdminService {
 
       DeleteTopicsResult deleteTopicsResult = kafkaClient.deleteTopics(topicsToBeDeleted);
 
-      processDeleteResult(tenantId, topicsToBeDeleted, deleteTopicsResult);
-    } catch (Exception ex) {
-      log.warn("Error occurred while deleting topics for tenantId: {}", tenantId, ex);
+      processDeleteResult(topicsToBeDeleted, deleteTopicsResult);
     }
   }
 
-  private static void processDeleteResult(String tenantId,
-                                          List<String> topicsToBeDeleted,
-                                          DeleteTopicsResult deleteTopicsResult) {
-    try {
-      deleteTopicsResult.all().get();
-      log.info("Topics deleted successfully: {}", topicsToBeDeleted);
-    } catch (Exception ex) {
-      log.warn("Unable to delete topics for tenantId: {}", tenantId, ex);
-    }
+  private static void processDeleteResult(List<String> topicsToBeDeleted,
+                                          DeleteTopicsResult deleteTopicsResult) throws Exception {
+    deleteTopicsResult.all().get();
+    log.info("Topics deleted successfully: {}", topicsToBeDeleted);
   }
 
   /**

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -3,18 +3,14 @@ package org.folio.spring.tools.kafka;
 import static java.util.Optional.ofNullable;
 import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName;
 
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.common.KafkaFuture;
-import org.apache.kafka.common.Uuid;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -103,6 +103,29 @@ class KafkaAdminServiceTest {
   }
 
   @Test
+  void deleteKafkaTopics_positive_withDeleteResult() {
+    FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
+    kafkaTopic.setName("test_topic");
+
+    var future = KafkaFuture.completedFuture(Set.of("folio.test_tenant.test_topic"));
+    var listTopicResult = mock(ListTopicsResult.class);
+    when(listTopicResult.names()).thenReturn(future);
+
+
+    when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
+    var kafkaClient = mock(AdminClient.class);
+    try (var ignored = mockStatic(AdminClient.class, (invocation) -> kafkaClient)) {
+      var deleteTopicsResult = mock(DeleteTopicsResult.class);
+      when(kafkaClient.listTopics()).thenReturn(listTopicResult);
+      when(kafkaClient.deleteTopics(anyCollection())).thenReturn(deleteTopicsResult);
+      kafkaAdminService.deleteTopics("test_tenant");
+    }
+
+    verify(kafkaClient).listTopics();
+    verify(kafkaClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
+  }
+
+  @Test
   void deleteKafkaTopics_positive_withNoTopicsFound() {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -10,9 +10,12 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.KafkaFuture;
 import org.folio.spring.tools.config.properties.FolioEnvironment;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -68,7 +71,7 @@ class KafkaAdminServiceTest {
       kafkaAdminService.deleteTopics("test_tenant");
     }
 
-    verify(kafkaClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
+    verify(kafkaClient).listTopics();
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -66,7 +66,7 @@ class KafkaAdminServiceTest {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
-    var future = KafkaFuture.completedFuture(Set.of("test_topic"));
+    var future = KafkaFuture.completedFuture(Set.of("folio.test_tenant.test_topic"));
     var listTopicResult = mock(ListTopicsResult.class);
     when(listTopicResult.names()).thenReturn(future);
 
@@ -78,7 +78,7 @@ class KafkaAdminServiceTest {
     }
 
     verify(kafkaClient).listTopics();
-    verify(kafkaClient).deleteTopics(List.of("test_topic"));
+    verify(kafkaClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -88,7 +88,7 @@ class KafkaAdminServiceTest {
       kafkaAdminService.deleteTopics("test_tenant");
     }
 
-    verify(kafkaClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
+    verify(kafkaClient).listTopics();
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -63,7 +63,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive() {
+  void deleteKafkaTopics_positive() throws Exception  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -83,7 +83,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive_withNoMatchingTopic() {
+  void deleteKafkaTopics_positive_withNoMatchingTopic() throws Exception  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -103,7 +103,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive_withDeleteResult() {
+  void deleteKafkaTopics_positive_withDeleteResult() throws Exception  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -126,7 +126,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive_withNoTopicsFound() {
+  void deleteKafkaTopics_positive_withNoTopicsFound() throws Exception  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -140,7 +140,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_negative_shouldHandleException() {
+  void deleteKafkaTopics_negative_shouldHandleException() throws Exception {
     var kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -157,7 +157,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_negative_shouldNotCallAnyMethodWithNoTenant() {
+  void deleteKafkaTopics_negative_shouldNotCallAnyMethodWithNoTenant() throws Exception  {
     var kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -74,7 +74,10 @@ class KafkaAdminServiceTest {
     when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
     var kafkaClient = mock(AdminClient.class);
     try (var ignored = mockStatic(AdminClient.class, (invocation) -> kafkaClient)) {
+      var deleteTopicsResult = mock(DeleteTopicsResult.class);
       when(kafkaClient.listTopics()).thenReturn(listTopicResult);
+      when(kafkaClient.deleteTopics(anyCollection())).thenReturn(deleteTopicsResult);
+      when(deleteTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(mock(Void.class)));
       kafkaAdminService.deleteTopics("test_tenant");
     }
 
@@ -100,29 +103,6 @@ class KafkaAdminServiceTest {
 
     verify(kafkaClient).listTopics();
     verify(kafkaClient, never()).deleteTopics(List.of("folio.test_tenant.test_topic"));
-  }
-
-  @Test
-  void deleteKafkaTopics_positive_withDeleteResult() throws Exception  {
-    FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
-    kafkaTopic.setName("test_topic");
-
-    var future = KafkaFuture.completedFuture(Set.of("folio.test_tenant.test_topic"));
-    var listTopicResult = mock(ListTopicsResult.class);
-    when(listTopicResult.names()).thenReturn(future);
-
-
-    when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
-    var kafkaClient = mock(AdminClient.class);
-    try (var ignored = mockStatic(AdminClient.class, (invocation) -> kafkaClient)) {
-      var deleteTopicsResult = mock(DeleteTopicsResult.class);
-      when(kafkaClient.listTopics()).thenReturn(listTopicResult);
-      when(kafkaClient.deleteTopics(anyCollection())).thenReturn(deleteTopicsResult);
-      kafkaAdminService.deleteTopics("test_tenant");
-    }
-
-    verify(kafkaClient).listTopics();
-    verify(kafkaClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Improve kafka topic deletion by tenant id

### Approach
Added completion logic for kafka topic deletion.

### Learning
[FST-60](https://issues.folio.org/browse/FST-60)
