### PR TITLE
FST-60: Improved kafka topic deletion by tenant id

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -5,6 +5,7 @@ import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName;
 
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -45,7 +46,7 @@ public class KafkaAdminService {
     kafkaAdmin.initialize();
   }
 
-  public void deleteTopics(String tenantId) throws Exception {
+  public void deleteTopics(String tenantId) {
     if (tenantId == null || tenantId.isEmpty()) {
       log.warn("Invalid tenantId: {}", tenantId);
       return;
@@ -63,7 +64,13 @@ public class KafkaAdminService {
         log.warn("No existing topics to delete for tenantId: {}", tenantId);
         return;
       }
-      Set<String> existingTopics = listTopicsResult.names().get();
+      Set<String> existingTopics = null;
+      try {
+        existingTopics = listTopicsResult.names().get();
+      } catch (InterruptedException | ExecutionException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
       List<String> topicsToBeDeleted = topicsToDelete.stream()
         .filter(existingTopics::contains)
         .toList();
@@ -80,8 +87,13 @@ public class KafkaAdminService {
   }
 
   private static void processDeleteResult(List<String> topicsToBeDeleted,
-                                          DeleteTopicsResult deleteTopicsResult) throws Exception {
-    deleteTopicsResult.all().get();
+                                          DeleteTopicsResult deleteTopicsResult) {
+    try {
+      deleteTopicsResult.all().get();
+    } catch (InterruptedException | ExecutionException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
     log.info("Topics deleted successfully: {}", topicsToBeDeleted);
   }
 
@@ -99,7 +111,7 @@ public class KafkaAdminService {
   }
 
   private List<NewTopic> toTenantSpecificTopic(List<FolioKafkaProperties.KafkaTopic> localConfigTopics,
-    String tenantId) {
+                                               String tenantId) {
     return localConfigTopics.stream()
       .map(topic -> toKafkaTopic(topic, tenantId))
       .toList();

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -64,7 +64,7 @@ public class KafkaAdminService {
         log.warn("No existing topics to delete for tenantId: {}", tenantId);
         return;
       }
-      Set<String> existingTopics = null;
+      Set<String> existingTopics;
       try {
         existingTopics = listTopicsResult.names().get();
       } catch (InterruptedException | ExecutionException e) {

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -83,17 +83,17 @@ public class KafkaAdminService {
 
       DeleteTopicsResult deleteTopicsResult = kafkaClient.deleteTopics(topicsToBeDeleted);
 
-      processDeleteResult(topicsToBeDeleted, deleteTopicsResult);
+      processDeleteResult(topicsToBeDeleted, deleteTopicsResult, tenantId);
     }
   }
 
   private static void processDeleteResult(List<String> topicsToBeDeleted,
-                                          DeleteTopicsResult deleteTopicsResult) {
+                                          DeleteTopicsResult deleteTopicsResult, String tenantId) {
     try {
       deleteTopicsResult.all().get();
     } catch (InterruptedException | ExecutionException e) {
       Thread.currentThread().interrupt();
-      throw new RuntimeException(e);
+      throw new KafkaException(String.format("There was an error while deleting topics by tenant: %s", tenantId));
     }
     log.info("Topics deleted successfully: {}", topicsToBeDeleted);
   }

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -14,6 +14,7 @@ import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.stereotype.Service;
@@ -69,7 +70,7 @@ public class KafkaAdminService {
         existingTopics = listTopicsResult.names().get();
       } catch (InterruptedException | ExecutionException e) {
         Thread.currentThread().interrupt();
-        throw new RuntimeException(e);
+        throw new KafkaException(String.format("No existing topics to delete for tenantId: %s", tenantId));
       }
       List<String> topicsToBeDeleted = topicsToDelete.stream()
         .filter(existingTopics::contains)

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -1,16 +1,14 @@
 package org.folio.spring.tools.kafka;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.ListTopicsResult;
@@ -83,6 +81,8 @@ class KafkaAdminServiceTest {
 
     verify(kafkaClient).listTopics();
     verify(kafkaClient).deleteTopics(List.of("folio.test_tenant.test_topic"));
+    assertThatThrownBy(()->kafkaAdminService.deleteTopics("folio.test_tenant.test_topic"))
+      .isInstanceOf(Exception.class);
   }
 
   @Test

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -63,7 +63,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive() throws Exception  {
+  void deleteKafkaTopics_positive()  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -86,7 +86,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive_withNoMatchingTopic() throws Exception  {
+  void deleteKafkaTopics_positive_withNoMatchingTopic()  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -106,7 +106,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_positive_withNoTopicsFound() throws Exception  {
+  void deleteKafkaTopics_positive_withNoTopicsFound()  {
     FolioKafkaProperties.KafkaTopic kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -120,7 +120,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_negative_shouldHandleException() throws Exception {
+  void deleteKafkaTopics_negative_shouldHandleException() {
     var kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 
@@ -137,7 +137,7 @@ class KafkaAdminServiceTest {
   }
 
   @Test
-  void deleteKafkaTopics_negative_shouldNotCallAnyMethodWithNoTenant() throws Exception  {
+  void deleteKafkaTopics_negative_shouldNotCallAnyMethodWithNoTenant()  {
     var kafkaTopic = new FolioKafkaProperties.KafkaTopic();
     kafkaTopic.setName("test_topic");
 

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.listener.MessageListenerContainer;
@@ -124,7 +125,7 @@ class KafkaAdminServiceTest {
     when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
     try (var ignored = mockStatic(AdminClient.class, (invocation) -> kafkaClient)) {
       when(kafkaClient.deleteTopics(anyCollection()))
-        .thenThrow(new IllegalStateException());
+        .thenThrow(new KafkaException(String.format("No existing topics to delete for tenantId: test_tenant")));
 
       kafkaAdminService.deleteTopics("test_tenant");
     }


### PR DESCRIPTION
### Purpose
Improve exception throwing

### Approach
Try catch blocks added in order to avoid possible conflicts.

### Learning
[FST-60](https://issues.folio.org/browse/FST-60)
