### PR TITLE
add tenant identifying header & add tenant collection topics

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
@@ -1,12 +1,13 @@
 package org.folio.spring.tools.kafka;
 
-import java.util.List;
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Application properties for kafka message consumer.
@@ -15,6 +16,10 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties("folio.kafka")
 public class FolioKafkaProperties {
+  /**
+   * Kafka header name for tenant_id
+   */
+  public static final String TENANT_ID = "folio.tenantId";
 
   /**
    * Map with settings for application kafka listeners.

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaTopic.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaTopic.java
@@ -3,6 +3,8 @@ package org.folio.spring.tools.kafka;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.spring.tools.config.properties.FolioEnvironment;
 
+import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName;
+
 public interface FolioKafkaTopic {
 
   String topicName();
@@ -17,7 +19,7 @@ public interface FolioKafkaTopic {
     if (StringUtils.isAnyBlank(envId, tenantId, topicName)) {
       throw new IllegalArgumentException("envId, tenantId, topicName can't be blank");
     }
-    return String.join(".", envId, tenantId, topicName);
+    return getTenantTopicName(topicName, envId, tenantId);
   }
 
 }

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaUtils.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaUtils.java
@@ -1,18 +1,50 @@
 package org.folio.spring.tools.kafka;
 
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.tools.config.properties.FolioEnvironment;
+import org.springframework.messaging.MessageHeaders;
+
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import lombok.experimental.UtilityClass;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.internals.RecordHeader;
-import org.folio.spring.tools.config.properties.FolioEnvironment;
-import org.springframework.messaging.MessageHeaders;
+
+import static org.folio.spring.tools.kafka.FolioKafkaProperties.TENANT_ID;
 
 @UtilityClass
 public class KafkaUtils {
+  private static final String TENANT_COLLECTION_TOPICS_ENV_VAR_NAME = "KAFKA_PRODUCER_TENANT_COLLECTION";
+  private static final String TENANT_COLLECTION_MATCH_REGEX = "[A-Z][A-Z0-9]{0,30}";
+  private static boolean TENANT_COLLECTION_TOPICS_ENABLED;
+  private static String TENANT_COLLECTION_TOPIC_QUALIFIER;
+
+  static {
+    TENANT_COLLECTION_TOPIC_QUALIFIER = System.getenv(TENANT_COLLECTION_TOPICS_ENV_VAR_NAME);
+    setTenantCollectionTopicsQualifier(TENANT_COLLECTION_TOPIC_QUALIFIER);
+  }
+
+  static void setTenantCollectionTopicsQualifier(String value) {
+    TENANT_COLLECTION_TOPIC_QUALIFIER = value;
+    TENANT_COLLECTION_TOPICS_ENABLED = !StringUtils.isEmpty(TENANT_COLLECTION_TOPIC_QUALIFIER);
+
+    if(TENANT_COLLECTION_TOPICS_ENABLED &&
+      !TENANT_COLLECTION_TOPIC_QUALIFIER.matches(TENANT_COLLECTION_MATCH_REGEX)){
+      throw new RuntimeException(
+        String.format("%s environment variable does not match %s",
+          TENANT_COLLECTION_TOPICS_ENV_VAR_NAME,
+          TENANT_COLLECTION_MATCH_REGEX));
+    }
+  }
+
+  public static boolean isTenantCollectionTopicsEnabled() {
+    return TENANT_COLLECTION_TOPICS_ENABLED;
+  }
 
   /**
    * Returns topic name in the format - `{env}.{tenant}.{topic-name}`
@@ -22,17 +54,30 @@ public class KafkaUtils {
    * @return topic name as {@link String} object
    */
   public static String getTenantTopicName(String initialName, String tenantId) {
-    return String.join(".", FolioEnvironment.getFolioEnvName(), tenantId, initialName);
+    return getTenantTopicName(initialName, FolioEnvironment.getFolioEnvName(), tenantId);
+  }
+
+  public static String getTenantTopicName(String initialName, String envName, String tenantId) {
+    var tenantToUse = TENANT_COLLECTION_TOPICS_ENABLED ? TENANT_COLLECTION_TOPIC_QUALIFIER : tenantId;
+
+    return String.join(".", envName, tenantToUse, initialName);
   }
 
   public static List<Header> toKafkaHeaders(Map<String, Collection<String>> requestHeaders) {
     if (requestHeaders == null || requestHeaders.isEmpty()) {
       return Collections.emptyList();
     }
-    return requestHeaders.entrySet().stream()
-      .map(header -> (Header) new RecordHeader(header.getKey(),
-        retrieveFirstSafe(header.getValue()).getBytes(StandardCharsets.UTF_8)))
-      .toList();
+    var list = new ArrayList<>(requestHeaders.entrySet()
+      .stream()
+      .map(header -> (Header) new RecordHeader(header.getKey(), retrieveFirstSafe(header.getValue()).getBytes(StandardCharsets.UTF_8)))
+      .toList());
+
+    var tenantValues = requestHeaders.get(XOkapiHeaders.TENANT);
+    if (tenantValues != null && !tenantValues.isEmpty()) {
+      list.add(new RecordHeader(TENANT_ID, retrieveFirstSafe(tenantValues).getBytes(StandardCharsets.UTF_8)));
+    }
+
+    return list;
   }
 
   public static String getHeaderValue(String headerName, MessageHeaders headers) {

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/TenantIdCheckInterceptor.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/TenantIdCheckInterceptor.java
@@ -1,0 +1,61 @@
+package org.folio.spring.tools.kafka;
+
+import lombok.extern.log4j.Log4j2;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+
+import java.util.Map;
+
+import static org.folio.spring.tools.kafka.FolioKafkaProperties.TENANT_ID;
+
+/**
+ * In order to register this interceptor simply add configuration to application.yml
+ * <pre>
+ *spring:
+ *   kafka:
+ *     producer:
+ *       properties:
+ *         interceptor:
+ *           classes: org.folio.spring.tools.kafka.TenantIdCheckInterceptor
+ * </pre>
+ */
+@Log4j2
+public class TenantIdCheckInterceptor implements ProducerInterceptor<String, String> {
+
+  protected static final String TENANT_ID_ERROR_MESSAGE = "Kafka record does not have a tenant identifying header: " + TENANT_ID + ". " +
+    "Use FolioMessageProducer<T extends BaseKafkaMessage> to build the record. TopicName={}";
+  @Override
+  public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
+    Headers headers = record.headers();
+    boolean isTenantIdHeaderExist = false;
+    for (Header header : headers) {
+      if (header.key().equals(TENANT_ID)) {
+        isTenantIdHeaderExist = true;
+        break;
+      }
+    }
+    if (!isTenantIdHeaderExist) {
+      log.error(TENANT_ID_ERROR_MESSAGE, record.topic());
+    }
+
+    return record;
+  }
+
+  @Override
+  public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
+
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+
+  }
+}

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaUtilsTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaUtilsTest.java
@@ -1,0 +1,65 @@
+package org.folio.spring.tools.kafka;
+
+import org.folio.spring.integration.XOkapiHeaders;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.folio.spring.tools.kafka.FolioKafkaProperties.TENANT_ID;
+import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName;
+import static org.folio.spring.tools.kafka.KafkaUtils.isTenantCollectionTopicsEnabled;
+import static org.folio.spring.tools.kafka.KafkaUtils.setTenantCollectionTopicsQualifier;
+import static org.folio.spring.tools.kafka.KafkaUtils.toKafkaHeaders;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class KafkaUtilsTest {
+  @AfterEach
+  public void tearDown(){
+    // revert qualifier since KafkaTopicNameHelper is static and can affect other tests
+    setTenantCollectionTopicsQualifier(null);
+  }
+
+  @Test
+  public void isTenantCollectionEnabled(){
+    assertFalse(isTenantCollectionTopicsEnabled());
+    setTenantCollectionTopicsQualifier("COLLECTION");
+    assertTrue(isTenantCollectionTopicsEnabled());
+  }
+
+  @Test
+  public void shouldErrorWhenBadTenantCollectionQualifier() {
+    assertThrows(RuntimeException.class, () -> setTenantCollectionTopicsQualifier("diku"));
+  }
+
+  @Test
+  public void shouldFormatTopicName() {
+    String topicName = getTenantTopicName("DI_COMPLETED","folio", "TEST");
+    assertNotNull(topicName);
+    assertEquals("folio.TEST.DI_COMPLETED", topicName);
+
+    // enable tenant collection topics
+    setTenantCollectionTopicsQualifier("COLLECTION");
+    topicName = getTenantTopicName("DI_COMPLETED","folio", "TEST");
+    assertNotNull(topicName);
+    assertEquals("folio.COLLECTION.DI_COMPLETED", topicName);
+  }
+
+  @Test
+  void toKafkaHeadersShouldIncludeTenantIdHeader() {
+    Map<String, Collection<String>> requestHeaders = new HashMap<>();
+    requestHeaders.put("SomeKey", List.of("SomeValue"));
+    requestHeaders.put(XOkapiHeaders.TENANT, List.of("TEST"));
+    var headers = toKafkaHeaders(requestHeaders);
+    var header = headers.stream().filter(h -> TENANT_ID.equals(h.key())).findFirst().orElseThrow();
+    assertEquals("TEST", new String(header.value(), StandardCharsets.UTF_8));
+  }
+}

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/TenantIdCheckInterceptorTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/TenantIdCheckInterceptorTest.java
@@ -1,0 +1,83 @@
+package org.folio.spring.tools.kafka;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.slf4j.helpers.MessageFormatter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.folio.spring.tools.kafka.FolioKafkaProperties.TENANT_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TenantIdCheckInterceptorTest {
+
+  private static TestAppender appender;
+
+  @BeforeAll
+  public static void classSetup() {
+    Logger logger = LogManager.getLogger(TenantIdCheckInterceptor.class.getName());
+    appender = new TestAppender("TestAppender", null);
+    ((LoggerContext) LogManager.getContext(false)).getConfiguration().addAppender(appender);
+    ((org.apache.logging.log4j.core.Logger) logger).addAppender(appender);
+    appender.start();
+  }
+
+  @Test
+  public void onSend() {
+    String topicName = "topicName";
+    String key = "key-0";
+    String value = "value-0";
+    //
+    // create a record with no headers, message should be logged
+    ProducerRecord<String, String> kafkaRecord = new ProducerRecord<>(topicName, 0, key, value);
+    TenantIdCheckInterceptor tenantIdCheckInterceptor = new TenantIdCheckInterceptor();
+
+    tenantIdCheckInterceptor.onSend(kafkaRecord);
+
+    assertEquals(1, appender.getMessages().size());
+    assertEquals(MessageFormatter.format(TenantIdCheckInterceptor.TENANT_ID_ERROR_MESSAGE, topicName).getMessage()
+      , appender.getMessages().get(0));
+
+    // clear logged messages
+    appender.clear();
+
+    // create record with necessary headers, message should not be logged
+    kafkaRecord = new ProducerRecord<>(topicName, 0, key, value);
+    kafkaRecord.headers().add(TENANT_ID, value.getBytes(StandardCharsets.UTF_8));
+
+    tenantIdCheckInterceptor.onSend(kafkaRecord);
+
+    assertEquals(0, appender.getMessages().size());
+  }
+
+  private static class TestAppender extends AbstractAppender {
+
+    private final List<String> messages = new ArrayList<>();
+
+    TestAppender(String name, org.apache.logging.log4j.core.Filter filter) {
+      super(name, filter, null);
+    }
+
+    @Override
+    public void append(LogEvent event) {
+      messages.add(event.getMessage().getFormattedMessage());
+    }
+
+    List<String> getMessages() {
+      return messages;
+    }
+
+    void clear() {
+      messages.clear();
+    }
+  }
+
+}


### PR DESCRIPTION
### Purpose
Ensure that tenant identifier is included in every message produced to Kafka.
Add the ability to produce messages to tenant collection topics. All messages for an event type is sent to one topic instead of multiple. This is configurable through an environment variable.
