### PR TITLE
FST-66 allow kafka topic names with namespace

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaUtils.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaUtils.java
@@ -63,6 +63,12 @@ public class KafkaUtils {
     return String.join(".", envName, tenantToUse, initialName);
   }
 
+  public static String getTenantTopicNameWithNamespace(String initialName, String envName, String tenantId, String namespace) {
+    var tenantToUse = TENANT_COLLECTION_TOPICS_ENABLED ? TENANT_COLLECTION_TOPIC_QUALIFIER : tenantId;
+
+    return String.join(".", envName, namespace, tenantToUse, initialName);
+  }
+
   public static List<Header> toKafkaHeaders(Map<String, Collection<String>> requestHeaders) {
     if (requestHeaders == null || requestHeaders.isEmpty()) {
       return Collections.emptyList();

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaUtilsTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaUtilsTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 
 import static org.folio.spring.tools.kafka.FolioKafkaProperties.TENANT_ID;
 import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicName;
+import static org.folio.spring.tools.kafka.KafkaUtils.getTenantTopicNameWithNamespace;
 import static org.folio.spring.tools.kafka.KafkaUtils.isTenantCollectionTopicsEnabled;
 import static org.folio.spring.tools.kafka.KafkaUtils.setTenantCollectionTopicsQualifier;
 import static org.folio.spring.tools.kafka.KafkaUtils.toKafkaHeaders;
@@ -42,15 +43,28 @@ class KafkaUtilsTest {
 
   @Test
   public void shouldFormatTopicName() {
-    String topicName = getTenantTopicName("DI_COMPLETED","folio", "TEST");
+    String initialName = "DI_COMPLETED";
+    String envName = "folio";
+    String namespace = "Default";
+    String tenantId = "TEST";
+
+    String topicName = getTenantTopicName(initialName, envName, tenantId);
     assertNotNull(topicName);
     assertEquals("folio.TEST.DI_COMPLETED", topicName);
 
+    String topicNameWithNamespace = getTenantTopicNameWithNamespace(initialName, envName, tenantId, namespace);
+    assertNotNull(topicNameWithNamespace);
+    assertEquals("folio.Default.TEST.DI_COMPLETED", topicNameWithNamespace);
+
     // enable tenant collection topics
     setTenantCollectionTopicsQualifier("COLLECTION");
-    topicName = getTenantTopicName("DI_COMPLETED","folio", "TEST");
+    topicName = getTenantTopicName(initialName, envName, tenantId);
     assertNotNull(topicName);
     assertEquals("folio.COLLECTION.DI_COMPLETED", topicName);
+
+    topicNameWithNamespace = getTenantTopicNameWithNamespace(initialName, envName, tenantId, namespace);
+    assertNotNull(topicNameWithNamespace);
+    assertEquals("folio.Default.COLLECTION.DI_COMPLETED", topicNameWithNamespace);
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Allow spring modules that already have namespaces in their topic names to use KafkaUtils. This will bring tenant collection topics to the module

### Approach
Add another method to create a tenant topic name with a namespace

### Learning
https://issues.folio.org/browse/FST-66
