### PR TITLE
fix(kafka): do not delete kafka topics if collection topic is enabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,25 @@
+## v4.1.0 YYYY-mm-DD - In progress
+### Breaking changes
+* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+
+### New APIs versions
+* Provides `API_NAME vX.Y`
+* Requires `API_NAME vX.Y`
+
+### Features
+* Description ([ISSUE](https://folio-org.atlassian.net//browse/ISSUE))
+
+### Bug fixes
+* Do not delete kafka topics if collection topic is enabled ([FST-77](https://folio-org.atlassian.net/browse/FST-77))
+
+### Tech Dept
+* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+
+### Dependencies
+* Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`
+* Add `LIB_NAME` `VERSION`
+* Remove `LIB_NAME`
+
 ## v4.0.0 2024-03-18
 ### Breaking changes
 * Remove system-user related functionality from "folio-service-tools-spring-dev" ([FST-68](https://issues.folio.org/browse/FST-68))

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/KafkaAdminService.java
@@ -48,6 +48,10 @@ public class KafkaAdminService {
   }
 
   public void deleteTopics(String tenantId) {
+    if (KafkaUtils.isTenantCollectionTopicsEnabled()) {
+      log.warn("Topics will not be deleted tenant collection topic feature is enabled");
+      return;
+    }
     if (tenantId == null || tenantId.isEmpty()) {
       log.warn("Invalid tenantId: {}", tenantId);
       return;

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/KafkaAdminServiceTest.java
@@ -35,6 +35,8 @@ import org.springframework.kafka.listener.MessageListenerContainer;
 @SpringBootTest(classes = KafkaAdminService.class)
 class KafkaAdminServiceTest {
 
+  private static final String TEST_TENANT = "test_tenant";
+
   @Autowired
   private KafkaAdminService kafkaAdminService;
   @Autowired
@@ -53,7 +55,7 @@ class KafkaAdminServiceTest {
       FolioKafkaProperties.KafkaTopic.of("topic2", null, (short) 2),
       FolioKafkaProperties.KafkaTopic.of("topic3", 30, (short) -1)));
 
-    kafkaAdminService.createTopics("test_tenant");
+    kafkaAdminService.createTopics(TEST_TENANT);
     verify(kafkaAdmin).initialize();
 
     var beansOfType = applicationContext.getBeansOfType(NewTopic.class);
@@ -80,7 +82,7 @@ class KafkaAdminServiceTest {
       when(kafkaClient.listTopics()).thenReturn(listTopicResult);
       when(kafkaClient.deleteTopics(anyCollection())).thenReturn(deleteTopicsResult);
       when(deleteTopicsResult.all()).thenReturn(KafkaFuture.completedFuture(mock(Void.class)));
-      kafkaAdminService.deleteTopics("test_tenant");
+      kafkaAdminService.deleteTopics(TEST_TENANT);
     }
 
     verify(kafkaClient).listTopics();
@@ -100,7 +102,7 @@ class KafkaAdminServiceTest {
     var kafkaClient = mock(AdminClient.class);
     try (var ignored = mockStatic(AdminClient.class, (invocation) -> kafkaClient)) {
       when(kafkaClient.listTopics()).thenReturn(listTopicResult);
-      kafkaAdminService.deleteTopics("test_tenant");
+      kafkaAdminService.deleteTopics(TEST_TENANT);
     }
 
     verify(kafkaClient).listTopics();
@@ -115,7 +117,7 @@ class KafkaAdminServiceTest {
     when(kafkaProperties.getTopics()).thenReturn(List.of(kafkaTopic));
     var kafkaClient = mock(AdminClient.class);
     try (var ignored = mockStatic(AdminClient.class, (invocation) -> kafkaClient)) {
-      kafkaAdminService.deleteTopics("test_tenant");
+      kafkaAdminService.deleteTopics(TEST_TENANT);
     }
 
     verify(kafkaClient).listTopics();
@@ -137,7 +139,7 @@ class KafkaAdminServiceTest {
       given(listTopicResult.names().get()).willAnswer(invocation -> {throw new InterruptedException();});
 
       assertThrows(InterruptedException.class, ()->{
-        kafkaAdminService.deleteTopics("test_tenant");
+        kafkaAdminService.deleteTopics(TEST_TENANT);
       });
 
     }
@@ -164,7 +166,7 @@ class KafkaAdminServiceTest {
       when(deleteTopicsResult.all()).thenThrow(new KafkaException("There was an error while deleting topics by tenant: test_tenant"));
 
       Exception exception = assertThrows(KafkaException.class, ()->{
-        kafkaAdminService.deleteTopics("test_tenant");
+        kafkaAdminService.deleteTopics(TEST_TENANT);
       });
 
       assertEquals("There was an error while deleting topics by tenant: test_tenant", exception.getMessage());
@@ -188,6 +190,18 @@ class KafkaAdminServiceTest {
     }
 
     verify(kafkaClient, never()).listTopics();
+  }
+
+
+  @Test
+  void deleteKafkaTopics_positive_shouldNotDeleteTopics_whenTenantCollectionFeatureIsEnabled()  {
+    try (var ignored = mockStatic(KafkaUtils.class)) {
+      when(KafkaUtils.isTenantCollectionTopicsEnabled()).thenReturn(true);
+
+      kafkaAdminService.deleteTopics(TEST_TENANT);
+    }
+
+    verify(kafkaAdmin, never()).describeTopics(any());
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Do not delete kafka topics if collection topic is enabled

### Approach
If collection topics feature is enabled then do nothing

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/FST-77
