### PR TITLE
FST-82: Ramsons dependencies: RMB 35.3.0, folio-spring-support 8.2.0

### DIFF
--- a/.github/workflows/postgres.yml
+++ b/.github/workflows/postgres.yml
@@ -1,0 +1,26 @@
+name: postgres
+on:
+  workflow_dispatch:
+    inputs:
+      postgres:
+        description: "List of postgres container images, to be injected as TESTCONTAINERS_POSTGRES_IMAGE"
+        default: '["postgres:16-alpine", "postgres:18-alpine"]'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        postgres: ${{ fromJSON(github.event.inputs.postgres) }}
+      fail-fast: false
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+        cache: maven
+    - run: mvn --batch-mode verify
+      env:
+        TESTCONTAINERS_POSTGRES_IMAGE: ${{ matrix.postgres }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,8 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Dependencies
-* Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`
+* Bump `RMB` from `35.2.2` to Ramsons version `35.3.0`.
+* Bump `folio-spring-support`/`folio-spring-base` from `8.2.0-SNAPSHOT` to Ramsons final version `8.2.0`.
 * Add `LIB_NAME` `VERSION`
 * Remove `LIB_NAME`
 

--- a/folio-service-tools-dev/pom.xml
+++ b/folio-service-tools-dev/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>

--- a/folio-service-tools-dev/src/test/java/org/folio/rest/tools/utils/ModuleName.java
+++ b/folio-service-tools-dev/src/test/java/org/folio/rest/tools/utils/ModuleName.java
@@ -4,4 +4,7 @@ public class ModuleName {
   public static String getModuleName() {
     return "unit_test_example_module";
   }
+  public static String getModuleVersion() {
+    return "99999.0.0";
+  }
 }

--- a/folio-service-tools-test/pom.xml
+++ b/folio-service-tools-test/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
 
     <log4j.version>2.24.0</log4j.version>
     <vertx.version>4.5.10</vertx.version>
-    <raml-module-builder.version>35.2.2</raml-module-builder.version>
+    <raml-module-builder.version>35.3.0</raml-module-builder.version>
 
     <spring-boot.version>3.3.4</spring-boot.version>
 
-    <folio-spring-base.version>8.2.0-SNAPSHOT</folio-spring-base.version>
+    <folio-spring-base.version>8.2.0</folio-spring-base.version>
 
     <!-- Test dependencies versions -->
     <mockito.version>5.14.0</mockito.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FST-82

For Ramsons:

Upgrade RMB from 35.2.2 to Ramsons version 35.3.0.

Upgrade folio-spring-support/folio-spring-base from 8.2.0-SNAPSHOT to Ramsons final version 8.2.0.

### Purpose
Upgrade dependencies for Ramsons.

### Approach
Change version in pom.xml

Add .github/workflows/postgres.yml, see https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-353

Bump log4j-slf4j-impl to log4j-slf4j2-impl for testcontainers logging.

Add getModuleVersion() to ModuleName.java, otherwise mock(PostgresClient.class) fails.

### Changes Checklist
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.