### PR TITLE
feat(kafka): Add `maxPollRecords` and `maxPollIntervalMs` to `KafkaListenerProperties`

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
@@ -61,6 +61,16 @@ public class FolioKafkaProperties {
      * The group id.
      */
     private String groupId;
+
+    /**
+     * Max amount of record for a single poll.
+     */
+    private Integer maxPollRecords;
+
+    /**
+     * Max processing time for a single poll.
+     */
+    private Long maxPollIntervalMs;
   }
 
   @Data

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/FolioKafkaPropertiesTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/FolioKafkaPropertiesTest.java
@@ -13,6 +13,8 @@ class FolioKafkaPropertiesTest {
     kafkaListenerProperties.setConcurrency(5);
     kafkaListenerProperties.setTopicPattern("test-topic");
     kafkaListenerProperties.setGroupId("test-group");
+    kafkaListenerProperties.setMaxPollRecords(200);
+    kafkaListenerProperties.setMaxPollIntervalMs(60_000L);
 
     var folioKafkaProperties = new FolioKafkaProperties();
     folioKafkaProperties.setListener(Map.of("events", kafkaListenerProperties));


### PR DESCRIPTION
### Purpose
Add `maxPollRecords` and `maxPollIntervalMs` to `KafkaListenerProperties`

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[FST-85](https://folio-org.atlassian.net/browse/FST-85)
[MSEARCH-873](https://folio-org.atlassian.net/browse/MSEARCH-873)
