### PR TITLE
feat(kafka): Add `autoOffsetReset` to `KafkaListenerProperties`

### DIFF
--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
@@ -3,6 +3,7 @@ package org.folio.spring.tools.kafka;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -71,6 +72,12 @@ public class FolioKafkaProperties {
      * Max processing time for a single poll.
      */
     private Integer maxPollIntervalMs;
+
+    /**
+     * Specifies what offset to set in case there's no commited offset.
+     * Either earliest available to read all messages still present in topic or latest to read only new messages.
+     */
+    private OffsetResetStrategy autoOffsetReset;
   }
 
   @Data

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/FolioKafkaPropertiesTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/FolioKafkaPropertiesTest.java
@@ -3,6 +3,7 @@ package org.folio.spring.tools.kafka;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.junit.jupiter.api.Test;
 
 class FolioKafkaPropertiesTest {
@@ -15,6 +16,7 @@ class FolioKafkaPropertiesTest {
     kafkaListenerProperties.setGroupId("test-group");
     kafkaListenerProperties.setMaxPollRecords(200);
     kafkaListenerProperties.setMaxPollIntervalMs(60_000);
+    kafkaListenerProperties.setAutoOffsetReset(OffsetResetStrategy.LATEST);
 
     var folioKafkaProperties = new FolioKafkaProperties();
     folioKafkaProperties.setListener(Map.of("events", kafkaListenerProperties));


### PR DESCRIPTION
### Purpose
Add `autoOffsetReset` to `KafkaListenerProperties`

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[FST-87](https://folio-org.atlassian.net/browse/FST-87)
[MODELINKS-298](https://folio-org.atlassian.net/browse/MODELINKS-298)