### PR TITLE
feat(kafka): introduce sharedGroup property to control Kafka consumer group behavior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,12 +2,8 @@
 ### Breaking changes
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
-### New APIs versions
-* Provides `API_NAME vX.Y`
-* Requires `API_NAME vX.Y`
-
 ### Features
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Introduce sharedGroup property to control Kafka consumer group behavior ([FST-95](https://folio-org.atlassian.net/browse/FST-95))
 
 ### Bug fixes
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
+++ b/folio-service-tools-spring-dev/src/main/java/org/folio/spring/tools/kafka/FolioKafkaProperties.java
@@ -1,14 +1,16 @@
 package org.folio.spring.tools.kafka;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.Map;
 
 /**
  * Application properties for kafka message consumer.
@@ -49,7 +51,7 @@ public class FolioKafkaProperties {
   public static class KafkaListenerProperties {
 
     /**
-     * List of topic to listen.
+     * Topic pattern for listener.
      */
     private String topicPattern;
 
@@ -59,7 +61,7 @@ public class FolioKafkaProperties {
     private Integer concurrency = 5;
 
     /**
-     * The group id.
+     * Consumer group id.
      */
     private String groupId;
 
@@ -78,6 +80,23 @@ public class FolioKafkaProperties {
      * Either earliest available to read all messages still present in topic or latest to read only new messages.
      */
     private OffsetResetStrategy autoOffsetReset;
+
+    /**
+     * Determines if the consumer group should be shared between multiple instances of the same module.
+     */
+    private boolean sharedGroup = true;
+
+    public String getGroupId() {
+      return sharedGroup ? groupId : groupId + "-" + getUniqueValue();
+    }
+
+    private String getUniqueValue() {
+      try {
+        return InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        return UUID.randomUUID().toString();
+      }
+    }
   }
 
   @Data

--- a/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/FolioKafkaPropertiesTest.java
+++ b/folio-service-tools-spring-dev/src/test/java/org/folio/spring/tools/kafka/FolioKafkaPropertiesTest.java
@@ -10,17 +10,38 @@ class FolioKafkaPropertiesTest {
 
   @Test
   void constructorTest() {
-    var kafkaListenerProperties = new FolioKafkaProperties.KafkaListenerProperties();
-    kafkaListenerProperties.setConcurrency(5);
-    kafkaListenerProperties.setTopicPattern("test-topic");
-    kafkaListenerProperties.setGroupId("test-group");
-    kafkaListenerProperties.setMaxPollRecords(200);
-    kafkaListenerProperties.setMaxPollIntervalMs(60_000);
-    kafkaListenerProperties.setAutoOffsetReset(OffsetResetStrategy.LATEST);
+    var initialValues = new FolioKafkaProperties.KafkaListenerProperties();
+    initialValues.setConcurrency(5);
+    initialValues.setTopicPattern("test-topic");
+    initialValues.setGroupId("test-group");
+    initialValues.setMaxPollRecords(200);
+    initialValues.setMaxPollIntervalMs(60_000);
+    initialValues.setAutoOffsetReset(OffsetResetStrategy.LATEST);
 
     var folioKafkaProperties = new FolioKafkaProperties();
-    folioKafkaProperties.setListener(Map.of("events", kafkaListenerProperties));
+    folioKafkaProperties.setListener(Map.of("events", initialValues));
 
     assertThat(folioKafkaProperties).isNotNull();
+    assertThat(folioKafkaProperties.getListener().get("events").getConcurrency()).isEqualTo(initialValues.getConcurrency());
+    assertThat(folioKafkaProperties.getListener().get("events").getTopicPattern()).isEqualTo(initialValues.getTopicPattern());
+    assertThat(folioKafkaProperties.getListener().get("events").getGroupId()).isEqualTo(initialValues.getGroupId());
+    assertThat(folioKafkaProperties.getListener().get("events").getMaxPollRecords()).isEqualTo(initialValues.getMaxPollRecords());
+    assertThat(folioKafkaProperties.getListener().get("events").getMaxPollIntervalMs()).isEqualTo(initialValues.getMaxPollIntervalMs());
+    assertThat(folioKafkaProperties.getListener().get("events").getAutoOffsetReset()).isEqualTo(initialValues.getAutoOffsetReset());
+    assertThat(folioKafkaProperties.getListener().get("events").isSharedGroup()).isTrue();
+  }
+
+  @Test
+  void constructorTestWithSharedGroupFalse() {
+    var initialValues = new FolioKafkaProperties.KafkaListenerProperties();
+    initialValues.setGroupId("test-group");
+    initialValues.setSharedGroup(false);
+
+    var folioKafkaProperties = new FolioKafkaProperties();
+    folioKafkaProperties.setListener(Map.of("events", initialValues));
+
+    assertThat(folioKafkaProperties).isNotNull();
+    assertThat(folioKafkaProperties.getListener().get("events").getGroupId()).startsWith("test-group-");
+    assertThat(folioKafkaProperties.getListener().get("events").isSharedGroup()).isFalse();
   }
 }


### PR DESCRIPTION
### Purpose
Introduce a new configuration property sharedGroup that will determine whether the groupId should be shared across all module instances or made unique per instance.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/FST-95